### PR TITLE
Add interactive Wheel of Forfeits web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-test
+# Wheel of Forfeits
+
+A standalone web experience for running a configurable wheel of fortune packed with custom forfeits.
+
+## Features
+
+- 🎡 Animated weighted wheel that visually reflects each forfeit's chance of being picked.
+- ➕ Slide-in manager to add, edit, or remove forfeits with per-item weights, dependency lists, and removal rules.
+- 🔁 Optional automatic removal of forfeits after they've been selected.
+- 🔗 Dependency handling so certain forfeits only become available once their prerequisites have been spun.
+- 💾 Import/export buttons to save your forfeit setups as JSON and load them back later.
+- 🕓 Recent spin history with timestamps and persistence via `localStorage`.
+
+## Getting Started
+
+1. Open `index.html` in a modern browser.
+2. Use **Manage Forfeits** to add forfeits. Provide a name, weight (chance), optional dependencies (comma separated names of forfeits that must already have been selected), and whether the entry should be removed after being chosen.
+3. Press **Spin** to animate the wheel and pick a random forfeit according to the weights. The result is announced and stored in the history panel.
+4. Export or import your forfeit list at any time to share with others or quickly configure the wheel.
+
+> ℹ️ All data is saved locally in your browser. Clearing site data or switching browsers will reset the wheel unless you export your forfeits first.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,451 @@
+const canvas = document.getElementById('wheel');
+const ctx = canvas.getContext('2d');
+const spinButton = document.getElementById('spin');
+const resultEl = document.getElementById('result');
+const historyEl = document.getElementById('history');
+const toggleMenuBtn = document.getElementById('toggle-menu');
+const menu = document.getElementById('menu');
+const form = document.getElementById('forfeit-form');
+const list = document.getElementById('forfeit-list');
+const template = document.getElementById('forfeit-row-template');
+const exportBtn = document.getElementById('export-forfeits');
+const importInput = document.getElementById('import-forfeits');
+const editDialog = document.getElementById('edit-dialog');
+const editForm = document.getElementById('edit-form');
+const closeMenuBtn = document.getElementById('close-menu');
+
+const STORAGE_KEY = 'wheel-of-forfeits';
+const HISTORY_KEY = 'wheel-of-forfeits-history';
+
+let forfeits = loadFromStorage(STORAGE_KEY, []);
+let selectionHistory = loadFromStorage(HISTORY_KEY, []);
+let spinning = false;
+let rotation = 0;
+
+function getCompletedNames() {
+  return new Set(selectionHistory.map((item) => item.name.toLowerCase()));
+}
+
+function updateMenuState() {
+  const isOpen = !menu.classList.contains('hidden');
+  document.body.classList.toggle('menu-open', isOpen);
+}
+
+function clone(value) {
+  if (typeof structuredClone === 'function') {
+    return structuredClone(value);
+  }
+  return JSON.parse(JSON.stringify(value));
+}
+
+function loadFromStorage(key, fallback) {
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return clone(fallback);
+    const parsed = JSON.parse(raw);
+    return parsed;
+  } catch (error) {
+    console.error('Failed to parse storage', error);
+    return clone(fallback);
+  }
+}
+
+function saveToStorage(key, value) {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch (error) {
+    console.error('Failed to save to storage', error);
+  }
+}
+
+function createId() {
+  if (window.crypto?.randomUUID) {
+    return window.crypto.randomUUID();
+  }
+  return `forfeit-${Math.random().toString(36).slice(2, 10)}${Date.now().toString(36)}`;
+}
+
+function normalizeForfeit(raw) {
+  return {
+    id: raw.id ?? createId(),
+    name: raw.name?.trim() || 'Unnamed',
+    weight: Math.max(0, Number.parseFloat(raw.weight ?? 1)) || 1,
+    dependencies: Array.isArray(raw.dependencies)
+      ? raw.dependencies.map((dep) => dep.trim()).filter(Boolean)
+      : String(raw.dependencies || '')
+          .split(',')
+          .map((dep) => dep.trim())
+          .filter(Boolean),
+    removeOnSelect: Boolean(raw.removeOnSelect),
+  };
+}
+
+function addForfeit(raw) {
+  const forfeit = normalizeForfeit(raw);
+  forfeits.push(forfeit);
+  sync();
+}
+
+function updateForfeit(id, raw) {
+  const index = forfeits.findIndex((f) => f.id === id);
+  if (index === -1) return;
+  forfeits[index] = { ...forfeits[index], ...normalizeForfeit({ ...forfeits[index], ...raw, id }) };
+  sync();
+}
+
+function deleteForfeit(id) {
+  forfeits = forfeits.filter((f) => f.id !== id);
+  sync();
+}
+
+function sync() {
+  saveToStorage(STORAGE_KEY, forfeits);
+  drawWheel();
+  renderList();
+}
+
+function renderList() {
+  list.innerHTML = '';
+  if (forfeits.length === 0) {
+    const empty = document.createElement('p');
+    empty.textContent = 'No forfeits yet. Add some to get spinning!';
+    empty.className = 'empty-state';
+    list.append(empty);
+    return;
+  }
+
+  const dependenciesMet = getCompletedNames();
+
+  for (const forfeit of forfeits) {
+    const node = template.content.firstElementChild.cloneNode(true);
+    node.dataset.id = forfeit.id;
+    node.querySelector('.forfeit-name').textContent = forfeit.name;
+
+    const details = [];
+    details.push(`Weight: ${forfeit.weight}`);
+    if (forfeit.dependencies.length > 0) {
+      const unmet = forfeit.dependencies.filter((dep) => !dependenciesMet.has(dep.toLowerCase()));
+      const dependencyText = unmet.length
+        ? `Dependencies: ${forfeit.dependencies.join(', ')} (unmet: ${unmet.join(', ')})`
+        : `Dependencies: ${forfeit.dependencies.join(', ')}`;
+      details.push(dependencyText);
+    }
+    details.push(forfeit.removeOnSelect ? 'Removed after selection' : 'Stays on wheel');
+    node.querySelector('.forfeit-details').textContent = details.join(' • ');
+
+    node.querySelector('.delete').addEventListener('click', () => deleteForfeit(forfeit.id));
+    node.querySelector('.edit').addEventListener('click', () => openEditDialog(forfeit));
+
+    list.append(node);
+  }
+}
+
+function getSegments(list) {
+  const totalWeight = list.reduce((sum, item) => sum + item.weight, 0);
+  if (totalWeight === 0) return [];
+  let start = 0;
+  return list.map((item, index) => {
+    const proportion = item.weight / totalWeight;
+    const angle = proportion * Math.PI * 2;
+    const segment = {
+      id: item.id,
+      item,
+      startAngle: start,
+      endAngle: start + angle,
+      index,
+      proportion,
+    };
+    start += angle;
+    return segment;
+  });
+}
+
+function drawWheel() {
+  const width = canvas.width;
+  const height = canvas.height;
+  const radius = Math.min(width, height) / 2;
+  ctx.clearRect(0, 0, width, height);
+
+  const centerX = width / 2;
+  const centerY = height / 2;
+
+  if (!forfeits.length) {
+    ctx.save();
+    ctx.fillStyle = '#eee';
+    ctx.beginPath();
+    ctx.arc(centerX, centerY, radius, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.fillStyle = '#666';
+    ctx.font = '20px sans-serif';
+    ctx.textAlign = 'center';
+    ctx.fillText('Add forfeits to spin', centerX, centerY);
+    ctx.restore();
+    drawPointer(centerX, centerY, radius);
+    return;
+  }
+
+  const dependenciesMet = getCompletedNames();
+  const segments = getSegments(forfeits);
+  if (segments.length === 0) {
+    ctx.save();
+    ctx.fillStyle = '#f0f0f0';
+    ctx.beginPath();
+    ctx.arc(centerX, centerY, radius, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.fillStyle = '#888';
+    ctx.font = '18px sans-serif';
+    ctx.textAlign = 'center';
+    ctx.fillText('Adjust weights to spin', centerX, centerY);
+    ctx.restore();
+    drawPointer(centerX, centerY, radius);
+    return;
+  }
+
+  ctx.save();
+  ctx.translate(centerX, centerY);
+  ctx.rotate(rotation);
+
+  segments.forEach((segment, index) => {
+    const { item, startAngle, endAngle } = segment;
+    const eligible = isEligible(item, dependenciesMet);
+
+    ctx.beginPath();
+    ctx.moveTo(0, 0);
+    ctx.fillStyle = eligible ? colorForIndex(index) : 'rgba(200, 200, 200, 0.5)';
+    ctx.arc(0, 0, radius, startAngle, endAngle);
+    ctx.closePath();
+    ctx.fill();
+
+    ctx.save();
+    ctx.fillStyle = eligible ? '#222' : '#666';
+    ctx.rotate((startAngle + endAngle) / 2);
+    ctx.textAlign = 'right';
+    ctx.font = '16px sans-serif';
+    ctx.fillText(item.name, radius - 10, 0);
+    ctx.restore();
+  });
+
+  ctx.restore();
+  drawPointer(centerX, centerY, radius);
+}
+
+function drawPointer(centerX, centerY, radius) {
+  ctx.save();
+  ctx.translate(centerX, centerY);
+  ctx.fillStyle = '#333';
+  ctx.beginPath();
+  ctx.moveTo(0, -radius - 10);
+  ctx.lineTo(-15, -radius + 20);
+  ctx.lineTo(15, -radius + 20);
+  ctx.closePath();
+  ctx.fill();
+  ctx.restore();
+}
+
+function colorForIndex(index) {
+  const hue = (index * 137.508) % 360; // golden angle
+  return `hsl(${hue}, 70%, 60%)`;
+}
+
+function isEligible(forfeit, dependenciesMet) {
+  if (forfeit.weight <= 0) return false;
+  if (!forfeit.dependencies || forfeit.dependencies.length === 0) return true;
+  return forfeit.dependencies.every((depName) => dependenciesMet.has(depName.toLowerCase()));
+}
+
+function chooseForfeit() {
+  const dependenciesMet = getCompletedNames();
+  const eligible = forfeits.filter((f) => isEligible(f, dependenciesMet));
+  if (!eligible.length) {
+    return null;
+  }
+  const totalWeight = eligible.reduce((sum, item) => sum + item.weight, 0);
+  let threshold = Math.random() * totalWeight;
+  for (const forfeit of eligible) {
+    threshold -= forfeit.weight;
+    if (threshold <= 0) {
+      return forfeit;
+    }
+  }
+  return eligible[eligible.length - 1];
+}
+
+function getSegmentForForfeit(target) {
+  const segments = getSegments(forfeits);
+  return segments.find((segment) => segment.item.id === target.id);
+}
+
+function animateSpin(targetSegment) {
+  return new Promise((resolve) => {
+    const pointerAngle = -Math.PI / 2;
+    const segmentCenter = (targetSegment.startAngle + targetSegment.endAngle) / 2;
+    const finalRotation = pointerAngle - segmentCenter;
+    const spins = 5 + Math.random() * 3;
+    const startRotation = rotation;
+    const targetRotation = finalRotation + spins * Math.PI * 2;
+    const duration = 4000;
+    const startTime = performance.now();
+
+    function frame(now) {
+      const elapsed = now - startTime;
+      const progress = Math.min(elapsed / duration, 1);
+      const eased = easeOutCubic(progress);
+      rotation = startRotation + (targetRotation - startRotation) * eased;
+      drawWheel();
+      if (progress < 1) {
+        requestAnimationFrame(frame);
+      } else {
+        rotation = rotation % (Math.PI * 2);
+        resolve();
+      }
+    }
+
+    requestAnimationFrame(frame);
+  });
+}
+
+function easeOutCubic(t) {
+  return 1 - Math.pow(1 - t, 3);
+}
+
+async function spin() {
+  if (spinning || forfeits.length === 0) return;
+  const selected = chooseForfeit();
+  if (!selected) {
+    resultEl.textContent = 'No eligible forfeits available yet.';
+    return;
+  }
+
+  const segment = getSegmentForForfeit(selected);
+  if (!segment) {
+    console.warn('Segment not found for selection');
+    return;
+  }
+
+  spinning = true;
+  spinButton.disabled = true;
+  resultEl.textContent = 'Spinning...';
+
+  await animateSpin(segment);
+
+  resultEl.textContent = `Result: ${selected.name}`;
+  selectionHistory.unshift({ id: selected.id, name: selected.name, timestamp: Date.now() });
+  selectionHistory = selectionHistory.slice(0, 50);
+  saveToStorage(HISTORY_KEY, selectionHistory);
+  renderHistory();
+
+  if (selected.removeOnSelect) {
+    deleteForfeit(selected.id);
+  }
+
+  spinning = false;
+  spinButton.disabled = false;
+}
+
+function renderHistory() {
+  if (!selectionHistory.length) {
+    historyEl.textContent = 'No spins yet.';
+    return;
+  }
+
+  const lines = selectionHistory.map((entry) => {
+    const date = new Date(entry.timestamp);
+    return `${date.toLocaleTimeString()} – ${entry.name}`;
+  });
+  historyEl.innerHTML = `<strong>History</strong><br>${lines.join('<br>')}`;
+}
+
+function openEditDialog(forfeit) {
+  editForm.name.value = forfeit.name;
+  editForm.weight.value = forfeit.weight;
+  editForm.dependencies.value = forfeit.dependencies.join(', ');
+  editForm.removeOnSelect.checked = Boolean(forfeit.removeOnSelect);
+  editDialog.returnValue = '';
+  editDialog.showModal();
+
+  function handleClose(event) {
+    if (event.target.returnValue === 'confirm') {
+      updateForfeit(forfeit.id, {
+        name: editForm.name.value,
+        weight: editForm.weight.value,
+        dependencies: editForm.dependencies.value,
+        removeOnSelect: editForm.removeOnSelect.checked,
+      });
+    }
+    editDialog.removeEventListener('close', handleClose);
+  }
+
+  editDialog.addEventListener('close', handleClose);
+}
+
+form.addEventListener('submit', (event) => {
+  event.preventDefault();
+  const formData = new FormData(form);
+  addForfeit({
+    name: formData.get('name'),
+    weight: formData.get('weight'),
+    dependencies: formData.get('dependencies'),
+    removeOnSelect: formData.get('removeOnSelect') !== null,
+  });
+  form.reset();
+  form.elements.weight.value = 1;
+  form.elements.removeOnSelect.checked = true;
+});
+
+spinButton.addEventListener('click', spin);
+
+toggleMenuBtn.addEventListener('click', () => {
+  menu.classList.toggle('hidden');
+  updateMenuState();
+});
+
+closeMenuBtn.addEventListener('click', () => {
+  menu.classList.add('hidden');
+  updateMenuState();
+});
+
+document.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape' && !menu.classList.contains('hidden')) {
+    menu.classList.add('hidden');
+    updateMenuState();
+  }
+});
+
+exportBtn.addEventListener('click', () => {
+  const data = JSON.stringify(forfeits, null, 2);
+  const blob = new Blob([data], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = 'forfeits.json';
+  link.click();
+  URL.revokeObjectURL(url);
+});
+
+importInput.addEventListener('change', async (event) => {
+  const file = event.target.files?.[0];
+  if (!file) return;
+  try {
+    const text = await file.text();
+    const parsed = JSON.parse(text);
+    if (!Array.isArray(parsed)) {
+      throw new Error('Invalid forfeits file');
+    }
+    const imported = parsed.map(normalizeForfeit);
+    forfeits = imported;
+    sync();
+  } catch (error) {
+    alert('Failed to import forfeits: ' + error.message);
+  } finally {
+    importInput.value = '';
+  }
+});
+
+function init() {
+  drawWheel();
+  renderList();
+  renderHistory();
+  updateMenuState();
+}
+
+init();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Wheel of Forfeits</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="app-header">
+    <h1>Wheel of Forfeits</h1>
+    <div class="header-actions">
+      <button id="toggle-menu" class="primary">Manage Forfeits</button>
+      <button id="export-forfeits" class="secondary">Export</button>
+      <label class="import-label secondary">
+        Import
+        <input id="import-forfeits" type="file" accept="application/json" />
+      </label>
+    </div>
+  </header>
+
+  <main class="app-main">
+    <section class="wheel-panel">
+      <canvas id="wheel" width="500" height="500" aria-label="Wheel of forfeits"></canvas>
+      <button id="spin" class="spin-button primary">Spin</button>
+      <div id="result" class="result" role="status" aria-live="polite"></div>
+      <div id="history" class="history"></div>
+    </section>
+
+    <aside id="menu" class="menu hidden" aria-label="Forfeit manager">
+      <header>
+        <h2>Forfeit Manager</h2>
+        <button type="button" id="close-menu" class="secondary">Close</button>
+      </header>
+      <form id="forfeit-form" class="forfeit-form">
+        <div class="form-row">
+          <label for="forfeit-name">Name</label>
+          <input id="forfeit-name" name="name" required />
+        </div>
+        <div class="form-row">
+          <label for="forfeit-weight">Weight</label>
+          <input id="forfeit-weight" name="weight" type="number" min="1" value="1" required />
+        </div>
+        <div class="form-row">
+          <label for="forfeit-dependencies">Dependencies<br /><small>(comma separated)</small></label>
+          <input id="forfeit-dependencies" name="dependencies" placeholder="e.g. Push-ups, Sing" />
+        </div>
+        <div class="form-row checkbox-row">
+          <input id="forfeit-remove" name="removeOnSelect" type="checkbox" checked />
+          <label for="forfeit-remove">Remove after chosen</label>
+        </div>
+        <button type="submit" class="primary">Add Forfeit</button>
+      </form>
+
+      <section class="forfeit-list-section">
+        <header>
+          <h3>Current Forfeits</h3>
+        </header>
+        <ul id="forfeit-list" class="forfeit-list"></ul>
+      </section>
+    </aside>
+  </main>
+
+  <template id="forfeit-row-template">
+    <li class="forfeit-row">
+      <div class="forfeit-summary">
+        <h4 class="forfeit-name"></h4>
+        <p class="forfeit-details"></p>
+      </div>
+      <div class="forfeit-actions">
+        <button class="secondary edit">Edit</button>
+        <button class="danger delete">Delete</button>
+      </div>
+    </li>
+  </template>
+
+  <dialog id="edit-dialog">
+    <form method="dialog" id="edit-form">
+      <h3>Edit Forfeit</h3>
+      <label>
+        Name
+        <input name="name" required />
+      </label>
+      <label>
+        Weight
+        <input name="weight" type="number" min="1" required />
+      </label>
+      <label>
+        Dependencies<br /><small>(comma separated)</small>
+        <input name="dependencies" />
+      </label>
+      <label class="dialog-checkbox">
+        <input name="removeOnSelect" type="checkbox" /> Remove after chosen
+      </label>
+      <menu>
+        <button value="cancel" class="secondary">Cancel</button>
+        <button value="confirm" class="primary">Save</button>
+      </menu>
+    </form>
+  </dialog>
+
+  <script src="app.js" type="module"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,287 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  --bg: #f7f7f7;
+  --bg-dark: #1f1f1f;
+  --text: #202020;
+  --text-dark: #f0f0f0;
+  --primary: #007bff;
+  --primary-dark: #4092ff;
+  --secondary: #6c757d;
+  --danger: #d9534f;
+  --surface: #ffffff;
+  --surface-dark: #2c2c2c;
+  --shadow: rgba(0, 0, 0, 0.15);
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+body.dark {
+  background: var(--bg-dark);
+  color: var(--text-dark);
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 2rem;
+  background: linear-gradient(135deg, #6f42c1, #ff7f50);
+  color: white;
+  box-shadow: 0 2px 8px var(--shadow);
+}
+
+.header-actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.import-label {
+  position: relative;
+  overflow: hidden;
+}
+
+#import-forfeits {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.app-main {
+  position: relative;
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+}
+
+.wheel-panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  padding: 2rem;
+}
+
+body.menu-open .wheel-panel {
+  margin-right: min(360px, 90vw);
+}
+
+#wheel {
+  max-width: 90vw;
+  border-radius: 50%;
+  box-shadow: 0 8px 24px var(--shadow);
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.9), rgba(240, 240, 240, 0.5));
+}
+
+.spin-button {
+  font-size: 1.25rem;
+  padding: 0.75rem 2.5rem;
+}
+
+.result {
+  min-height: 2rem;
+  font-size: 1.5rem;
+  font-weight: bold;
+  color: #6f42c1;
+}
+
+.history {
+  width: min(480px, 90vw);
+  max-height: 150px;
+  overflow-y: auto;
+  padding: 1rem;
+  border-radius: 12px;
+  background: rgba(111, 66, 193, 0.1);
+  box-shadow: inset 0 0 0 1px rgba(111, 66, 193, 0.2);
+}
+
+.menu {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: min(360px, 100%);
+  background: var(--surface);
+  box-shadow: -4px 0 16px rgba(0, 0, 0, 0.1);
+  padding: 2rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  transition: transform 0.3s ease-in-out, opacity 0.3s ease-in-out;
+  transform: translateX(100%);
+  opacity: 0;
+  pointer-events: none;
+}
+
+.menu > header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+body.dark .menu {
+  background: var(--surface-dark);
+}
+
+.menu:not(.hidden) {
+  transform: translateX(0);
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.forfeit-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.checkbox-row {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.forfeit-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  overflow-y: auto;
+  max-height: 40vh;
+}
+
+.forfeit-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  border-radius: 10px;
+  background: rgba(111, 66, 193, 0.08);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+}
+
+.forfeit-name {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.forfeit-details {
+  margin: 0.25rem 0 0;
+  font-size: 0.875rem;
+  color: #444;
+}
+
+body.dark .forfeit-details {
+  color: #bbb;
+}
+
+.forfeit-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.5rem 1.25rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button:active {
+  transform: scale(0.98);
+}
+
+button.primary {
+  background: var(--primary);
+  color: #fff;
+  box-shadow: 0 4px 12px rgba(0, 123, 255, 0.3);
+}
+
+button.primary:hover,
+button.primary:focus-visible {
+  background: var(--primary-dark);
+}
+
+button.secondary {
+  background: var(--secondary);
+  color: white;
+}
+
+button.danger {
+  background: var(--danger);
+  color: white;
+}
+
+input, textarea {
+  border-radius: 8px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  padding: 0.5rem 0.75rem;
+  font-size: 1rem;
+  font-family: inherit;
+}
+
+.dialog-checkbox {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.75rem;
+}
+
+@media (max-width: 900px) {
+  .app-main {
+    flex-direction: column;
+  }
+
+  .menu {
+    top: auto;
+    right: 0;
+    left: 0;
+    bottom: 0;
+    width: 100%;
+    transform: translateY(100%);
+  }
+
+  .menu:not(.hidden) {
+    transform: translateY(0);
+  }
+
+  body.menu-open .wheel-panel {
+    margin-right: 0;
+    margin-bottom: 320px;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: var(--bg-dark);
+    color: var(--text-dark);
+  }
+
+  .result {
+    color: #ffd166;
+  }
+}


### PR DESCRIPTION
## Summary
- build a standalone wheel of forfeits interface with animated canvas wheel, result display, and history
- add a slide-in manager for creating, editing, and deleting weighted forfeits with dependency and removal options
- support JSON import/export and local persistence so forfeits can be saved, restored, or shared

## Testing
- not run (static web app)


------
https://chatgpt.com/codex/tasks/task_e_68cbd7925c8483319344fde849fc0974