### PR TITLE
Improve menu readability and add dramatic celebration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A standalone web experience for running a configurable wheel of fortune packed w
 
 - 🎡 Animated weighted wheel that visually reflects each forfeit's chance of being picked.
 - ➕ Slide-in manager to add, edit, or remove forfeits with per-item weights, dependency lists, and removal rules.
-- 🔁 Optional automatic removal of forfeits after they've been selected.
+- 🔁 Optional automatic removal of forfeits after they've been selected, with the wheel disabling itself until a valid option exists.
 - 🔗 Dependency handling so certain forfeits only become available once their prerequisites have been spun.
 - 💾 Import/export buttons to save your forfeit setups as JSON and load them back later.
 - 🕓 Recent spin history with timestamps and persistence via `localStorage`.
@@ -14,7 +14,7 @@ A standalone web experience for running a configurable wheel of fortune packed w
 ## Getting Started
 
 1. Open `index.html` in a modern browser.
-2. Use **Manage Forfeits** to add forfeits. Provide a name, weight (chance), optional dependencies (comma separated names of forfeits that must already have been selected), and whether the entry should be removed after being chosen.
+2. Use **Manage Forfeits** to add forfeits. Provide a name, weight (chance), optional dependencies (comma separated names of forfeits that must already have been selected), and whether the entry should be removed after being chosen. Locked entries are shown with a "(locked)" badge until their prerequisites have been spun.
 3. Press **Spin** to animate the wheel and pick a random forfeit according to the weights. The result is announced and stored in the history panel.
 4. Export or import your forfeit list at any time to share with others or quickly configure the wheel.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A standalone web experience for running a configurable wheel of fortune packed w
 
 - 🎡 Animated weighted wheel that visually reflects each forfeit's chance of being picked.
 - ➕ Slide-in manager to add, edit, or remove forfeits with per-item weights, dependency lists, and removal rules.
-- 🔁 Optional automatic removal of forfeits after they've been selected, with the wheel disabling itself until a valid option exists.
+- 🔁 Optional automatic removal of forfeits after they've been selected, with the wheel pausing spins until at least one eligible option remains.
 - 🔗 Dependency handling so certain forfeits only become available once their prerequisites have been spun.
 - 💾 Import/export buttons to save your forfeit setups as JSON and load them back later.
 - 🕓 Recent spin history with timestamps and persistence via `localStorage`.
@@ -14,7 +14,7 @@ A standalone web experience for running a configurable wheel of fortune packed w
 ## Getting Started
 
 1. Open `index.html` in a modern browser.
-2. Use **Manage Forfeits** to add forfeits. Provide a name, weight (chance), optional dependencies (comma separated names of forfeits that must already have been selected), and whether the entry should be removed after being chosen. Locked entries are shown with a "(locked)" badge until their prerequisites have been spun.
+2. Use **Manage Forfeits** to add forfeits. Provide a name, weight (chance), optional dependencies (comma separated names of forfeits that must already have been selected), and whether the entry should be removed after being chosen. Locked entries are shown with a "(locked)" badge until their prerequisites have been spun, and the wheel stays disabled until at least one unlocked option is available.
 3. Press **Spin** to animate the wheel and pick a random forfeit according to the weights. The result is announced and stored in the history panel.
 4. Export or import your forfeit list at any time to share with others or quickly configure the wheel.
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-test
+# Wheel of Forfeits
+
+A standalone web experience for running a configurable wheel of fortune packed with custom forfeits.
+
+## Features
+
+- 🎡 Animated weighted wheel that visually reflects each forfeit's chance of being picked.
+- ➕ Slide-in manager to add, edit, or remove forfeits with per-item weights, dependency lists, and removal rules.
+- 🔁 Optional automatic removal of forfeits after they've been selected.
+- 🔗 Dependency handling so certain forfeits only become available once their prerequisites have been spun.
+- 💾 Import/export buttons to save your forfeit setups as JSON and load them back later.
+- 🕓 Recent spin history with timestamps and persistence via `localStorage`.
+
+## Getting Started
+
+1. Open `index.html` in a modern browser.
+2. Use **Manage Forfeits** to add forfeits. Provide a name, weight (chance), optional dependencies (comma separated names of forfeits that must already have been selected), and whether the entry should be removed after being chosen.
+3. Press **Spin** to animate the wheel and pick a random forfeit according to the weights. The result is announced and stored in the history panel.
+4. Export or import your forfeit list at any time to share with others or quickly configure the wheel.
+
+> ℹ️ All data is saved locally in your browser. Clearing site data or switching browsers will reset the wheel unless you export your forfeits first.

--- a/app.js
+++ b/app.js
@@ -24,494 +24,494 @@ let spinning = false;
 let rotation = 0;
 
 function getCompletedNames() {
-  return new Set(selectionHistory.map((item) => item.name.toLowerCase()));
+	return new Set(selectionHistory.map((item) => item.name.toLowerCase()));
 }
 
 function updateMenuState() {
-  const isOpen = !menu.classList.contains('hidden');
-  document.body.classList.toggle('menu-open', isOpen);
+	const isOpen = !menu.classList.contains('hidden');
+	document.body.classList.toggle('menu-open', isOpen);
 }
 
 function clone(value) {
-  if (typeof structuredClone === 'function') {
-    return structuredClone(value);
-  }
-  return JSON.parse(JSON.stringify(value));
+	if (typeof structuredClone === 'function') {
+		return structuredClone(value);
+	}
+	return JSON.parse(JSON.stringify(value));
 }
 
 function loadFromStorage(key, fallback) {
-  try {
-    const raw = localStorage.getItem(key);
-    if (!raw) return clone(fallback);
-    const parsed = JSON.parse(raw);
-    return parsed;
-  } catch (error) {
-    console.error('Failed to parse storage', error);
-    return clone(fallback);
-  }
+	try {
+		const raw = localStorage.getItem(key);
+		if (!raw) return clone(fallback);
+		const parsed = JSON.parse(raw);
+		return parsed;
+	} catch (error) {
+		console.error('Failed to parse storage', error);
+		return clone(fallback);
+	}
 }
 
 function saveToStorage(key, value) {
-  try {
-    localStorage.setItem(key, JSON.stringify(value));
-  } catch (error) {
-    console.error('Failed to save to storage', error);
-  }
+	try {
+		localStorage.setItem(key, JSON.stringify(value));
+	} catch (error) {
+		console.error('Failed to save to storage', error);
+	}
 }
 
 function createId() {
-  if (window.crypto?.randomUUID) {
-    return window.crypto.randomUUID();
-  }
-  return `forfeit-${Math.random().toString(36).slice(2, 10)}${Date.now().toString(36)}`;
+	if (window.crypto?.randomUUID) {
+		return window.crypto.randomUUID();
+	}
+	return `forfeit-${Math.random().toString(36).slice(2, 10)}${Date.now().toString(36)}`;
 }
 
 function normalizeForfeit(raw) {
-  return {
-    id: raw.id ?? createId(),
-    name: raw.name?.trim() || 'Unnamed',
-    weight: Math.max(0, Number.parseFloat(raw.weight ?? 1)) || 1,
-    dependencies: Array.isArray(raw.dependencies)
-      ? raw.dependencies.map((dep) => dep.trim()).filter(Boolean)
-      : String(raw.dependencies || '')
-          .split(',')
-          .map((dep) => dep.trim())
-          .filter(Boolean),
-    removeOnSelect: Boolean(raw.removeOnSelect),
-  };
+	return {
+		id: raw.id ?? createId(),
+		name: raw.name?.trim() || 'Unnamed',
+		weight: Math.max(0, Number.parseFloat(raw.weight ?? 1)) || 1,
+		dependencies: Array.isArray(raw.dependencies)
+			? raw.dependencies.map((dep) => dep.trim()).filter(Boolean)
+			: String(raw.dependencies || '')
+					.split(',')
+					.map((dep) => dep.trim())
+					.filter(Boolean),
+		removeOnSelect: Boolean(raw.removeOnSelect),
+	};
 }
 
 function addForfeit(raw) {
-  const forfeit = normalizeForfeit(raw);
-  forfeits.push(forfeit);
-  sync();
+	const forfeit = normalizeForfeit(raw);
+	forfeits.push(forfeit);
+	sync();
 }
 
 function updateForfeit(id, raw) {
-  const index = forfeits.findIndex((f) => f.id === id);
-  if (index === -1) return;
-  forfeits[index] = { ...forfeits[index], ...normalizeForfeit({ ...forfeits[index], ...raw, id }) };
-  sync();
+	const index = forfeits.findIndex((f) => f.id === id);
+	if (index === -1) return;
+	forfeits[index] = { ...forfeits[index], ...normalizeForfeit({ ...forfeits[index], ...raw, id }) };
+	sync();
 }
 
 function deleteForfeit(id) {
-  forfeits = forfeits.filter((f) => f.id !== id);
-  sync();
+	forfeits = forfeits.filter((f) => f.id !== id);
+	sync();
 }
 
 function sync() {
-  saveToStorage(STORAGE_KEY, forfeits);
-  drawWheel();
-  renderList();
-  updateSpinAvailability();
+	saveToStorage(STORAGE_KEY, forfeits);
+	drawWheel();
+	renderList();
+	updateSpinAvailability();
 }
 
 function renderList() {
-  list.innerHTML = '';
-  if (forfeits.length === 0) {
-    const empty = document.createElement('p');
-    empty.textContent = 'No forfeits yet. Add some to get spinning!';
-    empty.className = 'empty-state';
-    list.append(empty);
-    return;
-  }
+	list.innerHTML = '';
+	if (forfeits.length === 0) {
+		const empty = document.createElement('p');
+		empty.textContent = 'No forfeits yet. Add some to get spinning!';
+		empty.className = 'empty-state';
+		list.append(empty);
+		return;
+	}
 
-  const dependenciesMet = getCompletedNames();
+	const dependenciesMet = getCompletedNames();
 
-  for (const forfeit of forfeits) {
-    const node = template.content.firstElementChild.cloneNode(true);
-    node.dataset.id = forfeit.id;
-    node.querySelector('.forfeit-name').textContent = forfeit.name;
+	for (const forfeit of forfeits) {
+		const node = template.content.firstElementChild.cloneNode(true);
+		node.dataset.id = forfeit.id;
+		node.querySelector('.forfeit-name').textContent = forfeit.name;
 
-    const details = [];
-    details.push(`Weight: ${forfeit.weight}`);
-    if (forfeit.dependencies.length > 0) {
-      const unmet = forfeit.dependencies.filter((dep) => !dependenciesMet.has(dep.toLowerCase()));
-      const dependencyText = unmet.length
-        ? `Dependencies: ${forfeit.dependencies.join(', ')} (unmet: ${unmet.join(', ')})`
-        : `Dependencies: ${forfeit.dependencies.join(', ')}`;
-      details.push(dependencyText);
-    }
-    details.push(forfeit.removeOnSelect ? 'Removed after selection' : 'Stays on wheel');
-    node.querySelector('.forfeit-details').textContent = details.join(' • ');
+		const details = [];
+		details.push(`Weight: ${forfeit.weight}`);
+		if (forfeit.dependencies.length > 0) {
+			const unmet = forfeit.dependencies.filter((dep) => !dependenciesMet.has(dep.toLowerCase()));
+			const dependencyText = unmet.length
+				? `Dependencies: ${forfeit.dependencies.join(', ')} (unmet: ${unmet.join(', ')})`
+				: `Dependencies: ${forfeit.dependencies.join(', ')}`;
+			details.push(dependencyText);
+		}
+		details.push(forfeit.removeOnSelect ? 'Removed after selection' : 'Stays on wheel');
+		node.querySelector('.forfeit-details').textContent = details.join(' • ');
 
-    const eligible = isEligible(forfeit, dependenciesMet);
-    node.classList.toggle('ineligible', !eligible);
-    node.setAttribute('aria-disabled', String(!eligible));
+		const eligible = isEligible(forfeit, dependenciesMet);
+		node.classList.toggle('ineligible', !eligible);
+		node.setAttribute('aria-disabled', String(!eligible));
 
-    node.querySelector('.delete').addEventListener('click', () => deleteForfeit(forfeit.id));
-    node.querySelector('.edit').addEventListener('click', () => openEditDialog(forfeit));
+		node.querySelector('.delete').addEventListener('click', () => deleteForfeit(forfeit.id));
+		node.querySelector('.edit').addEventListener('click', () => openEditDialog(forfeit));
 
-    list.append(node);
-  }
+		list.append(node);
+	}
 }
 
 function getSegments(list) {
-  const totalWeight = list.reduce((sum, item) => sum + item.weight, 0);
-  if (totalWeight === 0) return [];
-  let start = 0;
-  return list.map((item, index) => {
-    const proportion = item.weight / totalWeight;
-    const angle = proportion * Math.PI * 2;
-    const segment = {
-      id: item.id,
-      item,
-      startAngle: start,
-      endAngle: start + angle,
-      index,
-      proportion,
-    };
-    start += angle;
-    return segment;
-  });
+	const totalWeight = list.reduce((sum, item) => sum + item.weight, 0);
+	if (totalWeight === 0) return [];
+	let start = 0;
+	return list.map((item, index) => {
+		const proportion = item.weight / totalWeight;
+		const angle = proportion * Math.PI * 2;
+		const segment = {
+			id: item.id,
+			item,
+			startAngle: start,
+			endAngle: start + angle,
+			index,
+			proportion,
+		};
+		start += angle;
+		return segment;
+	});
 }
 
 function drawWheel() {
-  const width = canvas.width;
-  const height = canvas.height;
-  const radius = Math.min(width, height) / 2;
-  ctx.clearRect(0, 0, width, height);
+	const width = canvas.width;
+	const height = canvas.height;
+	const radius = Math.min(width, height) / 2;
+	ctx.clearRect(0, 0, width, height);
 
-  const centerX = width / 2;
-  const centerY = height / 2;
+	const centerX = width / 2;
+	const centerY = height / 2;
 
-  if (!forfeits.length) {
-    ctx.save();
-    ctx.fillStyle = '#eee';
-    ctx.beginPath();
-    ctx.arc(centerX, centerY, radius, 0, Math.PI * 2);
-    ctx.fill();
-    ctx.fillStyle = '#666';
-    ctx.font = '20px sans-serif';
-    ctx.textAlign = 'center';
-    ctx.fillText('Add forfeits to spin', centerX, centerY);
-    ctx.restore();
-    drawPointer(centerX, centerY, radius);
-    return;
-  }
+	if (!forfeits.length) {
+		ctx.save();
+		ctx.fillStyle = '#eee';
+		ctx.beginPath();
+		ctx.arc(centerX, centerY, radius, 0, Math.PI * 2);
+		ctx.fill();
+		ctx.fillStyle = '#666';
+		ctx.font = '20px sans-serif';
+		ctx.textAlign = 'center';
+		ctx.fillText('Add forfeits to spin', centerX, centerY);
+		ctx.restore();
+		drawPointer(centerX, centerY, radius);
+		return;
+	}
 
-  const dependenciesMet = getCompletedNames();
-  const segments = getSegments(forfeits);
-  if (segments.length === 0) {
-    ctx.save();
-    ctx.fillStyle = '#f0f0f0';
-    ctx.beginPath();
-    ctx.arc(centerX, centerY, radius, 0, Math.PI * 2);
-    ctx.fill();
-    ctx.fillStyle = '#888';
-    ctx.font = '18px sans-serif';
-    ctx.textAlign = 'center';
-    ctx.fillText('Adjust weights to spin', centerX, centerY);
-    ctx.restore();
-    drawPointer(centerX, centerY, radius);
-    return;
-  }
+	const dependenciesMet = getCompletedNames();
+	const segments = getSegments(forfeits);
+	if (segments.length === 0) {
+		ctx.save();
+		ctx.fillStyle = '#f0f0f0';
+		ctx.beginPath();
+		ctx.arc(centerX, centerY, radius, 0, Math.PI * 2);
+		ctx.fill();
+		ctx.fillStyle = '#888';
+		ctx.font = '18px sans-serif';
+		ctx.textAlign = 'center';
+		ctx.fillText('Adjust weights to spin', centerX, centerY);
+		ctx.restore();
+		drawPointer(centerX, centerY, radius);
+		return;
+	}
 
-  ctx.save();
-  ctx.translate(centerX, centerY);
-  ctx.rotate(rotation);
+	ctx.save();
+	ctx.translate(centerX, centerY);
+	ctx.rotate(rotation);
 
-  let eligibleCount = 0;
+	let eligibleCount = 0;
 
-  segments.forEach((segment, index) => {
-    const { item, startAngle, endAngle } = segment;
-    const eligible = isEligible(item, dependenciesMet);
-    if (eligible) {
-      eligibleCount += 1;
-    }
+	segments.forEach((segment, index) => {
+		const { item, startAngle, endAngle } = segment;
+		const eligible = isEligible(item, dependenciesMet);
+		if (eligible) {
+			eligibleCount += 1;
+		}
 
-    ctx.beginPath();
-    ctx.moveTo(0, 0);
-    ctx.fillStyle = eligible ? colorForIndex(index) : 'rgba(200, 200, 200, 0.5)';
-    ctx.arc(0, 0, radius, startAngle, endAngle);
-    ctx.closePath();
-    ctx.fill();
+		ctx.beginPath();
+		ctx.moveTo(0, 0);
+		ctx.fillStyle = eligible ? colorForIndex(index) : 'rgba(200, 200, 200, 0.5)';
+		ctx.arc(0, 0, radius, startAngle, endAngle);
+		ctx.closePath();
+		ctx.fill();
 
-    ctx.save();
-    ctx.fillStyle = eligible ? '#222' : '#666';
-    ctx.rotate((startAngle + endAngle) / 2);
-    ctx.textAlign = 'right';
-    ctx.font = '16px sans-serif';
-    ctx.fillText(item.name, radius - 10, 0);
-    ctx.restore();
-  });
+		ctx.save();
+		ctx.fillStyle = eligible ? '#222' : '#666';
+		ctx.rotate((startAngle + endAngle) / 2);
+		ctx.textAlign = 'right';
+		ctx.font = '16px sans-serif';
+		ctx.fillText(item.name, radius - 10, 0);
+		ctx.restore();
+	});
 
-  ctx.restore();
-  if (eligibleCount === 0) {
-    ctx.save();
-    ctx.fillStyle = 'rgba(0, 0, 0, 0.65)';
-    ctx.beginPath();
-    ctx.arc(centerX, centerY, radius * 0.6, 0, Math.PI * 2);
-    ctx.fill();
-    ctx.fillStyle = '#fff';
-    ctx.font = 'bold 20px sans-serif';
-    ctx.textAlign = 'center';
-    ctx.fillText('All forfeits locked', centerX, centerY - 10);
-    ctx.font = '16px sans-serif';
-    ctx.fillText('Complete prerequisites to spin', centerX, centerY + 16);
-    ctx.restore();
-  }
-  drawPointer(centerX, centerY, radius);
+	ctx.restore();
+	if (eligibleCount === 0) {
+		ctx.save();
+		ctx.fillStyle = 'rgba(0, 0, 0, 0.65)';
+		ctx.beginPath();
+		ctx.arc(centerX, centerY, radius * 0.6, 0, Math.PI * 2);
+		ctx.fill();
+		ctx.fillStyle = '#fff';
+		ctx.font = 'bold 20px sans-serif';
+		ctx.textAlign = 'center';
+		ctx.fillText('All forfeits locked', centerX, centerY - 10);
+		ctx.font = '16px sans-serif';
+		ctx.fillText('Complete prerequisites to spin', centerX, centerY + 16);
+		ctx.restore();
+	}
+	drawPointer(centerX, centerY, radius);
 }
 
 function drawPointer(centerX, centerY, radius) {
-  ctx.save();
-  ctx.translate(centerX, centerY);
-  ctx.fillStyle = '#333';
-  ctx.beginPath();
-  ctx.moveTo(0, -radius - 10);
-  ctx.lineTo(-15, -radius + 20);
-  ctx.lineTo(15, -radius + 20);
-  ctx.closePath();
-  ctx.fill();
-  ctx.restore();
+	ctx.save();
+	ctx.translate(centerX, centerY);
+	ctx.fillStyle = '#333';
+	ctx.beginPath();
+	ctx.moveTo(0, -radius - 10);
+	ctx.lineTo(-15, -radius + 20);
+	ctx.lineTo(15, -radius + 20);
+	ctx.closePath();
+	ctx.fill();
+	ctx.restore();
 }
 
 function colorForIndex(index) {
-  const hue = (index * 137.508) % 360; // golden angle
-  return `hsl(${hue}, 70%, 60%)`;
+	const hue = (index * 137.508) % 360; // golden angle
+	return `hsl(${hue}, 70%, 60%)`;
 }
 
 function isEligible(forfeit, dependenciesMet) {
-  if (forfeit.weight <= 0) return false;
-  if (!forfeit.dependencies || forfeit.dependencies.length === 0) return true;
-  return forfeit.dependencies.every((depName) => dependenciesMet.has(depName.toLowerCase()));
+	if (forfeit.weight <= 0) return false;
+	if (!forfeit.dependencies || forfeit.dependencies.length === 0) return true;
+	return forfeit.dependencies.every((depName) => dependenciesMet.has(depName.toLowerCase()));
 }
 
 function getEligibleForfeits() {
-  const dependenciesMet = getCompletedNames();
-  return forfeits.filter((f) => isEligible(f, dependenciesMet));
+	const dependenciesMet = getCompletedNames();
+	return forfeits.filter((f) => isEligible(f, dependenciesMet));
 }
 
 function updateSpinAvailability() {
-  const eligible = getEligibleForfeits();
-  const hasEligible = eligible.length > 0;
-  spinButton.disabled = !hasEligible || spinning;
-  spinButton.title = hasEligible
-    ? 'Spin the wheel'
-    : 'Add eligible forfeits with weight above zero and satisfied dependencies to spin';
-  spinButton.setAttribute('aria-disabled', String(!hasEligible));
-  if (!hasEligible && !spinning && (!resultEl.textContent || resultEl.textContent.startsWith('Waiting'))) {
-    resultEl.textContent = 'Waiting for eligible forfeits...';
-  }
+	const eligible = getEligibleForfeits();
+	const hasEligible = eligible.length > 0;
+	spinButton.disabled = !hasEligible || spinning;
+	spinButton.title = hasEligible
+		? 'Spin the wheel'
+		: 'Add eligible forfeits with weight above zero and satisfied dependencies to spin';
+	spinButton.setAttribute('aria-disabled', String(!hasEligible));
+	if (!hasEligible && !spinning && (!resultEl.textContent || resultEl.textContent.startsWith('Waiting'))) {
+		resultEl.textContent = 'Waiting for eligible forfeits...';
+	}
 }
 
 function chooseForfeit() {
-  const eligible = getEligibleForfeits();
-  if (!eligible.length) {
-    return null;
-  }
-  const totalWeight = eligible.reduce((sum, item) => sum + item.weight, 0);
-  let threshold = Math.random() * totalWeight;
-  for (const forfeit of eligible) {
-    threshold -= forfeit.weight;
-    if (threshold <= 0) {
-      return forfeit;
-    }
-  }
-  return eligible[eligible.length - 1];
+	const eligible = getEligibleForfeits();
+	if (!eligible.length) {
+		return null;
+	}
+	const totalWeight = eligible.reduce((sum, item) => sum + item.weight, 0);
+	let threshold = Math.random() * totalWeight;
+	for (const forfeit of eligible) {
+		threshold -= forfeit.weight;
+		if (threshold <= 0) {
+			return forfeit;
+		}
+	}
+	return eligible[eligible.length - 1];
 }
 
 function getSegmentForForfeit(target) {
-  const segments = getSegments(forfeits);
-  return segments.find((segment) => segment.item.id === target.id);
+	const segments = getSegments(forfeits);
+	return segments.find((segment) => segment.item.id === target.id);
 }
 
 function animateSpin(targetSegment) {
-  return new Promise((resolve) => {
-    const pointerAngle = -Math.PI / 2;
-    const segmentCenter = (targetSegment.startAngle + targetSegment.endAngle) / 2;
-    const finalRotation = pointerAngle - segmentCenter;
-    const spins = 6 + Math.random() * 4;
-    const startRotation = rotation;
-    const targetRotation = finalRotation + spins * Math.PI * 2;
-    const duration = 5200;
-    const startTime = performance.now();
+	return new Promise((resolve) => {
+		const pointerAngle = -Math.PI / 2;
+		const segmentCenter = (targetSegment.startAngle + targetSegment.endAngle) / 2;
+		const finalRotation = pointerAngle - segmentCenter;
+		const spins = 6 + Math.random() * 4;
+		const startRotation = rotation;
+		const targetRotation = finalRotation + spins * Math.PI * 2;
+		const duration = 5200;
+		const startTime = performance.now();
 
-    function frame(now) {
-      const elapsed = now - startTime;
-      const progress = Math.min(elapsed / duration, 1);
-      const eased = easeOutExpo(progress);
-      rotation = startRotation + (targetRotation - startRotation) * eased;
-      drawWheel();
-      if (progress < 1) {
-        requestAnimationFrame(frame);
-      } else {
-        rotation = rotation % (Math.PI * 2);
-        resolve();
-      }
-    }
+		function frame(now) {
+			const elapsed = now - startTime;
+			const progress = Math.min(elapsed / duration, 1);
+			const eased = easeOutExpo(progress);
+			rotation = startRotation + (targetRotation - startRotation) * eased;
+			drawWheel();
+			if (progress < 1) {
+				requestAnimationFrame(frame);
+			} else {
+				rotation = rotation % (Math.PI * 2);
+				resolve();
+			}
+		}
 
-    requestAnimationFrame(frame);
-  });
+		requestAnimationFrame(frame);
+	});
 }
 
 function easeOutExpo(t) {
-  if (t === 1) return 1;
-  return 1 - Math.pow(2, -10 * t);
+	if (t === 1) return 1;
+	return 1 - Math.pow(2, -10 * t);
 }
 
 async function spin() {
-  if (spinning || forfeits.length === 0) return;
-  const selected = chooseForfeit();
-  if (!selected) {
-    resultEl.textContent = 'No eligible forfeits available yet.';
-    updateSpinAvailability();
-    return;
-  }
+	if (spinning || forfeits.length === 0) return;
+	const selected = chooseForfeit();
+	if (!selected) {
+		resultEl.textContent = 'No eligible forfeits available yet.';
+		updateSpinAvailability();
+		return;
+	}
 
-  const segment = getSegmentForForfeit(selected);
-  if (!segment) {
-    console.warn('Segment not found for selection');
-    return;
-  }
+	const segment = getSegmentForForfeit(selected);
+	if (!segment) {
+		console.warn('Segment not found for selection');
+		return;
+	}
 
-  spinning = true;
-  updateSpinAvailability();
-  resultEl.textContent = 'Spinning...';
+	spinning = true;
+	updateSpinAvailability();
+	resultEl.textContent = 'Spinning...';
 
-  await animateSpin(segment);
+	await animateSpin(segment);
 
-  resultEl.textContent = `Result: ${selected.name}`;
-  triggerCelebration(selected.name);
-  selectionHistory.unshift({ id: selected.id, name: selected.name, timestamp: Date.now() });
-  selectionHistory = selectionHistory.slice(0, 50);
-  saveToStorage(HISTORY_KEY, selectionHistory);
-  renderHistory();
+	resultEl.textContent = `Result: ${selected.name}`;
+	triggerCelebration(selected.name);
+	selectionHistory.unshift({ id: selected.id, name: selected.name, timestamp: Date.now() });
+	selectionHistory = selectionHistory.slice(0, 50);
+	saveToStorage(HISTORY_KEY, selectionHistory);
+	renderHistory();
 
-  if (selected.removeOnSelect) {
-    deleteForfeit(selected.id);
-  }
+	if (selected.removeOnSelect) {
+		deleteForfeit(selected.id);
+	}
 
-  spinning = false;
-  updateSpinAvailability();
+	spinning = false;
+	updateSpinAvailability();
 }
 
 function renderHistory() {
-  if (!selectionHistory.length) {
-    historyEl.textContent = 'No spins yet.';
-    return;
-  }
+	if (!selectionHistory.length) {
+		historyEl.textContent = 'No spins yet.';
+		return;
+	}
 
-  const lines = selectionHistory.map((entry) => {
-    const date = new Date(entry.timestamp);
-    return `${date.toLocaleTimeString()} – ${entry.name}`;
-  });
-  historyEl.innerHTML = `<strong>History</strong><br>${lines.join('<br>')}`;
+	const lines = selectionHistory.map((entry) => {
+		const date = new Date(entry.timestamp);
+		return `${date.toLocaleTimeString()} – ${entry.name}`;
+	});
+	historyEl.innerHTML = `<strong>History</strong><br>${lines.join('<br>')}`;
 }
 
 function openEditDialog(forfeit) {
-  editForm.name.value = forfeit.name;
-  editForm.weight.value = forfeit.weight;
-  editForm.dependencies.value = forfeit.dependencies.join(', ');
-  editForm.removeOnSelect.checked = Boolean(forfeit.removeOnSelect);
-  editDialog.returnValue = '';
-  editDialog.showModal();
+	editForm.name.value = forfeit.name;
+	editForm.weight.value = forfeit.weight;
+	editForm.dependencies.value = forfeit.dependencies.join(', ');
+	editForm.removeOnSelect.checked = Boolean(forfeit.removeOnSelect);
+	editDialog.returnValue = '';
+	editDialog.showModal();
 
-  function handleClose(event) {
-    if (event.target.returnValue === 'confirm') {
-      updateForfeit(forfeit.id, {
-        name: editForm.name.value,
-        weight: editForm.weight.value,
-        dependencies: editForm.dependencies.value,
-        removeOnSelect: editForm.removeOnSelect.checked,
-      });
-    }
-    editDialog.removeEventListener('close', handleClose);
-  }
+	function handleClose(event) {
+		if (event.target.returnValue === 'confirm') {
+			updateForfeit(forfeit.id, {
+				name: editForm.name.value,
+				weight: editForm.weight.value,
+				dependencies: editForm.dependencies.value,
+				removeOnSelect: editForm.removeOnSelect.checked,
+			});
+		}
+		editDialog.removeEventListener('close', handleClose);
+	}
 
-  editDialog.addEventListener('close', handleClose);
+	editDialog.addEventListener('close', handleClose);
 }
 
 function triggerCelebration(name) {
-  if (!celebrationEl) return;
-  celebrationEl.textContent = name;
-  celebrationEl.classList.remove('hidden');
-  celebrationEl.classList.remove('show');
+	if (!celebrationEl) return;
+	celebrationEl.textContent = name;
+	celebrationEl.classList.remove('hidden');
+	celebrationEl.classList.remove('show');
 
-  // Force reflow so the animation restarts even if the same name repeats
-  void celebrationEl.offsetWidth;
+	// Force reflow so the animation restarts even if the same name repeats
+	void celebrationEl.offsetWidth;
 
-  celebrationEl.classList.add('show');
+	celebrationEl.classList.add('show');
 
-  const handleAnimationEnd = () => {
-    celebrationEl.classList.add('hidden');
-    celebrationEl.classList.remove('show');
-    celebrationEl.removeEventListener('animationend', handleAnimationEnd);
-  };
+	const handleAnimationEnd = () => {
+		celebrationEl.classList.add('hidden');
+		celebrationEl.classList.remove('show');
+		celebrationEl.removeEventListener('animationend', handleAnimationEnd);
+	};
 
-  celebrationEl.addEventListener('animationend', handleAnimationEnd);
+	celebrationEl.addEventListener('animationend', handleAnimationEnd);
 }
 
 form.addEventListener('submit', (event) => {
-  event.preventDefault();
-  const formData = new FormData(form);
-  addForfeit({
-    name: formData.get('name'),
-    weight: formData.get('weight'),
-    dependencies: formData.get('dependencies'),
-    removeOnSelect: formData.get('removeOnSelect') !== null,
-  });
-  form.reset();
-  form.elements.weight.value = 1;
-  form.elements.removeOnSelect.checked = true;
+	event.preventDefault();
+	const formData = new FormData(form);
+	addForfeit({
+		name: formData.get('name'),
+		weight: formData.get('weight'),
+		dependencies: formData.get('dependencies'),
+		removeOnSelect: formData.get('removeOnSelect') !== null,
+	});
+	form.reset();
+	form.elements.weight.value = 1;
+	form.elements.removeOnSelect.checked = true;
 });
 
 spinButton.addEventListener('click', spin);
 
 toggleMenuBtn.addEventListener('click', () => {
-  menu.classList.toggle('hidden');
-  updateMenuState();
+	menu.classList.toggle('hidden');
+	updateMenuState();
 });
 
 closeMenuBtn.addEventListener('click', () => {
-  menu.classList.add('hidden');
-  updateMenuState();
+	menu.classList.add('hidden');
+	updateMenuState();
 });
 
 document.addEventListener('keydown', (event) => {
-  if (event.key === 'Escape' && !menu.classList.contains('hidden')) {
-    menu.classList.add('hidden');
-    updateMenuState();
-  }
+	if (event.key === 'Escape' && !menu.classList.contains('hidden')) {
+		menu.classList.add('hidden');
+		updateMenuState();
+	}
 });
 
 exportBtn.addEventListener('click', () => {
-  const data = JSON.stringify(forfeits, null, 2);
-  const blob = new Blob([data], { type: 'application/json' });
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement('a');
-  link.href = url;
-  link.download = 'forfeits.json';
-  link.click();
-  URL.revokeObjectURL(url);
+	const data = JSON.stringify(forfeits, null, 2);
+	const blob = new Blob([data], { type: 'application/json' });
+	const url = URL.createObjectURL(blob);
+	const link = document.createElement('a');
+	link.href = url;
+	link.download = 'forfeits.json';
+	link.click();
+	URL.revokeObjectURL(url);
 });
 
 importInput.addEventListener('change', async (event) => {
-  const file = event.target.files?.[0];
-  if (!file) return;
-  try {
-    const text = await file.text();
-    const parsed = JSON.parse(text);
-    if (!Array.isArray(parsed)) {
-      throw new Error('Invalid forfeits file');
-    }
-    const imported = parsed.map(normalizeForfeit);
-    forfeits = imported;
-    sync();
-  } catch (error) {
-    alert('Failed to import forfeits: ' + error.message);
-  } finally {
-    importInput.value = '';
-  }
+	const file = event.target.files?.[0];
+	if (!file) return;
+	try {
+		const text = await file.text();
+		const parsed = JSON.parse(text);
+		if (!Array.isArray(parsed)) {
+			throw new Error('Invalid forfeits file');
+		}
+		const imported = parsed.map(normalizeForfeit);
+		forfeits = imported;
+		sync();
+	} catch (error) {
+		alert('Failed to import forfeits: ' + error.message);
+	} finally {
+		importInput.value = '';
+	}
 });
 
 function init() {
-  drawWheel();
-  renderList();
-  renderHistory();
-  updateMenuState();
-  updateSpinAvailability();
+	drawWheel();
+	renderList();
+	renderHistory();
+	updateMenuState();
+	updateSpinAvailability();
 }
 
 init();

--- a/app.js
+++ b/app.js
@@ -1,0 +1,474 @@
+const canvas = document.getElementById('wheel');
+const ctx = canvas.getContext('2d');
+const spinButton = document.getElementById('spin');
+const resultEl = document.getElementById('result');
+const historyEl = document.getElementById('history');
+const toggleMenuBtn = document.getElementById('toggle-menu');
+const menu = document.getElementById('menu');
+const form = document.getElementById('forfeit-form');
+const list = document.getElementById('forfeit-list');
+const template = document.getElementById('forfeit-row-template');
+const exportBtn = document.getElementById('export-forfeits');
+const importInput = document.getElementById('import-forfeits');
+const editDialog = document.getElementById('edit-dialog');
+const editForm = document.getElementById('edit-form');
+const closeMenuBtn = document.getElementById('close-menu');
+const celebrationEl = document.getElementById('celebration');
+
+const STORAGE_KEY = 'wheel-of-forfeits';
+const HISTORY_KEY = 'wheel-of-forfeits-history';
+
+let forfeits = loadFromStorage(STORAGE_KEY, []);
+let selectionHistory = loadFromStorage(HISTORY_KEY, []);
+let spinning = false;
+let rotation = 0;
+
+function getCompletedNames() {
+  return new Set(selectionHistory.map((item) => item.name.toLowerCase()));
+}
+
+function updateMenuState() {
+  const isOpen = !menu.classList.contains('hidden');
+  document.body.classList.toggle('menu-open', isOpen);
+}
+
+function clone(value) {
+  if (typeof structuredClone === 'function') {
+    return structuredClone(value);
+  }
+  return JSON.parse(JSON.stringify(value));
+}
+
+function loadFromStorage(key, fallback) {
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return clone(fallback);
+    const parsed = JSON.parse(raw);
+    return parsed;
+  } catch (error) {
+    console.error('Failed to parse storage', error);
+    return clone(fallback);
+  }
+}
+
+function saveToStorage(key, value) {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch (error) {
+    console.error('Failed to save to storage', error);
+  }
+}
+
+function createId() {
+  if (window.crypto?.randomUUID) {
+    return window.crypto.randomUUID();
+  }
+  return `forfeit-${Math.random().toString(36).slice(2, 10)}${Date.now().toString(36)}`;
+}
+
+function normalizeForfeit(raw) {
+  return {
+    id: raw.id ?? createId(),
+    name: raw.name?.trim() || 'Unnamed',
+    weight: Math.max(0, Number.parseFloat(raw.weight ?? 1)) || 1,
+    dependencies: Array.isArray(raw.dependencies)
+      ? raw.dependencies.map((dep) => dep.trim()).filter(Boolean)
+      : String(raw.dependencies || '')
+          .split(',')
+          .map((dep) => dep.trim())
+          .filter(Boolean),
+    removeOnSelect: Boolean(raw.removeOnSelect),
+  };
+}
+
+function addForfeit(raw) {
+  const forfeit = normalizeForfeit(raw);
+  forfeits.push(forfeit);
+  sync();
+}
+
+function updateForfeit(id, raw) {
+  const index = forfeits.findIndex((f) => f.id === id);
+  if (index === -1) return;
+  forfeits[index] = { ...forfeits[index], ...normalizeForfeit({ ...forfeits[index], ...raw, id }) };
+  sync();
+}
+
+function deleteForfeit(id) {
+  forfeits = forfeits.filter((f) => f.id !== id);
+  sync();
+}
+
+function sync() {
+  saveToStorage(STORAGE_KEY, forfeits);
+  drawWheel();
+  renderList();
+}
+
+function renderList() {
+  list.innerHTML = '';
+  if (forfeits.length === 0) {
+    const empty = document.createElement('p');
+    empty.textContent = 'No forfeits yet. Add some to get spinning!';
+    empty.className = 'empty-state';
+    list.append(empty);
+    return;
+  }
+
+  const dependenciesMet = getCompletedNames();
+
+  for (const forfeit of forfeits) {
+    const node = template.content.firstElementChild.cloneNode(true);
+    node.dataset.id = forfeit.id;
+    node.querySelector('.forfeit-name').textContent = forfeit.name;
+
+    const details = [];
+    details.push(`Weight: ${forfeit.weight}`);
+    if (forfeit.dependencies.length > 0) {
+      const unmet = forfeit.dependencies.filter((dep) => !dependenciesMet.has(dep.toLowerCase()));
+      const dependencyText = unmet.length
+        ? `Dependencies: ${forfeit.dependencies.join(', ')} (unmet: ${unmet.join(', ')})`
+        : `Dependencies: ${forfeit.dependencies.join(', ')}`;
+      details.push(dependencyText);
+    }
+    details.push(forfeit.removeOnSelect ? 'Removed after selection' : 'Stays on wheel');
+    node.querySelector('.forfeit-details').textContent = details.join(' • ');
+
+    node.querySelector('.delete').addEventListener('click', () => deleteForfeit(forfeit.id));
+    node.querySelector('.edit').addEventListener('click', () => openEditDialog(forfeit));
+
+    list.append(node);
+  }
+}
+
+function getSegments(list) {
+  const totalWeight = list.reduce((sum, item) => sum + item.weight, 0);
+  if (totalWeight === 0) return [];
+  let start = 0;
+  return list.map((item, index) => {
+    const proportion = item.weight / totalWeight;
+    const angle = proportion * Math.PI * 2;
+    const segment = {
+      id: item.id,
+      item,
+      startAngle: start,
+      endAngle: start + angle,
+      index,
+      proportion,
+    };
+    start += angle;
+    return segment;
+  });
+}
+
+function drawWheel() {
+  const width = canvas.width;
+  const height = canvas.height;
+  const radius = Math.min(width, height) / 2;
+  ctx.clearRect(0, 0, width, height);
+
+  const centerX = width / 2;
+  const centerY = height / 2;
+
+  if (!forfeits.length) {
+    ctx.save();
+    ctx.fillStyle = '#eee';
+    ctx.beginPath();
+    ctx.arc(centerX, centerY, radius, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.fillStyle = '#666';
+    ctx.font = '20px sans-serif';
+    ctx.textAlign = 'center';
+    ctx.fillText('Add forfeits to spin', centerX, centerY);
+    ctx.restore();
+    drawPointer(centerX, centerY, radius);
+    return;
+  }
+
+  const dependenciesMet = getCompletedNames();
+  const segments = getSegments(forfeits);
+  if (segments.length === 0) {
+    ctx.save();
+    ctx.fillStyle = '#f0f0f0';
+    ctx.beginPath();
+    ctx.arc(centerX, centerY, radius, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.fillStyle = '#888';
+    ctx.font = '18px sans-serif';
+    ctx.textAlign = 'center';
+    ctx.fillText('Adjust weights to spin', centerX, centerY);
+    ctx.restore();
+    drawPointer(centerX, centerY, radius);
+    return;
+  }
+
+  ctx.save();
+  ctx.translate(centerX, centerY);
+  ctx.rotate(rotation);
+
+  segments.forEach((segment, index) => {
+    const { item, startAngle, endAngle } = segment;
+    const eligible = isEligible(item, dependenciesMet);
+
+    ctx.beginPath();
+    ctx.moveTo(0, 0);
+    ctx.fillStyle = eligible ? colorForIndex(index) : 'rgba(200, 200, 200, 0.5)';
+    ctx.arc(0, 0, radius, startAngle, endAngle);
+    ctx.closePath();
+    ctx.fill();
+
+    ctx.save();
+    ctx.fillStyle = eligible ? '#222' : '#666';
+    ctx.rotate((startAngle + endAngle) / 2);
+    ctx.textAlign = 'right';
+    ctx.font = '16px sans-serif';
+    ctx.fillText(item.name, radius - 10, 0);
+    ctx.restore();
+  });
+
+  ctx.restore();
+  drawPointer(centerX, centerY, radius);
+}
+
+function drawPointer(centerX, centerY, radius) {
+  ctx.save();
+  ctx.translate(centerX, centerY);
+  ctx.fillStyle = '#333';
+  ctx.beginPath();
+  ctx.moveTo(0, -radius - 10);
+  ctx.lineTo(-15, -radius + 20);
+  ctx.lineTo(15, -radius + 20);
+  ctx.closePath();
+  ctx.fill();
+  ctx.restore();
+}
+
+function colorForIndex(index) {
+  const hue = (index * 137.508) % 360; // golden angle
+  return `hsl(${hue}, 70%, 60%)`;
+}
+
+function isEligible(forfeit, dependenciesMet) {
+  if (forfeit.weight <= 0) return false;
+  if (!forfeit.dependencies || forfeit.dependencies.length === 0) return true;
+  return forfeit.dependencies.every((depName) => dependenciesMet.has(depName.toLowerCase()));
+}
+
+function chooseForfeit() {
+  const dependenciesMet = getCompletedNames();
+  const eligible = forfeits.filter((f) => isEligible(f, dependenciesMet));
+  if (!eligible.length) {
+    return null;
+  }
+  const totalWeight = eligible.reduce((sum, item) => sum + item.weight, 0);
+  let threshold = Math.random() * totalWeight;
+  for (const forfeit of eligible) {
+    threshold -= forfeit.weight;
+    if (threshold <= 0) {
+      return forfeit;
+    }
+  }
+  return eligible[eligible.length - 1];
+}
+
+function getSegmentForForfeit(target) {
+  const segments = getSegments(forfeits);
+  return segments.find((segment) => segment.item.id === target.id);
+}
+
+function animateSpin(targetSegment) {
+  return new Promise((resolve) => {
+    const pointerAngle = -Math.PI / 2;
+    const segmentCenter = (targetSegment.startAngle + targetSegment.endAngle) / 2;
+    const finalRotation = pointerAngle - segmentCenter;
+    const spins = 6 + Math.random() * 4;
+    const startRotation = rotation;
+    const targetRotation = finalRotation + spins * Math.PI * 2;
+    const duration = 5200;
+    const startTime = performance.now();
+
+    function frame(now) {
+      const elapsed = now - startTime;
+      const progress = Math.min(elapsed / duration, 1);
+      const eased = easeOutExpo(progress);
+      rotation = startRotation + (targetRotation - startRotation) * eased;
+      drawWheel();
+      if (progress < 1) {
+        requestAnimationFrame(frame);
+      } else {
+        rotation = rotation % (Math.PI * 2);
+        resolve();
+      }
+    }
+
+    requestAnimationFrame(frame);
+  });
+}
+
+function easeOutExpo(t) {
+  if (t === 1) return 1;
+  return 1 - Math.pow(2, -10 * t);
+}
+
+async function spin() {
+  if (spinning || forfeits.length === 0) return;
+  const selected = chooseForfeit();
+  if (!selected) {
+    resultEl.textContent = 'No eligible forfeits available yet.';
+    return;
+  }
+
+  const segment = getSegmentForForfeit(selected);
+  if (!segment) {
+    console.warn('Segment not found for selection');
+    return;
+  }
+
+  spinning = true;
+  spinButton.disabled = true;
+  resultEl.textContent = 'Spinning...';
+
+  await animateSpin(segment);
+
+  resultEl.textContent = `Result: ${selected.name}`;
+  triggerCelebration(selected.name);
+  selectionHistory.unshift({ id: selected.id, name: selected.name, timestamp: Date.now() });
+  selectionHistory = selectionHistory.slice(0, 50);
+  saveToStorage(HISTORY_KEY, selectionHistory);
+  renderHistory();
+
+  if (selected.removeOnSelect) {
+    deleteForfeit(selected.id);
+  }
+
+  spinning = false;
+  spinButton.disabled = false;
+}
+
+function renderHistory() {
+  if (!selectionHistory.length) {
+    historyEl.textContent = 'No spins yet.';
+    return;
+  }
+
+  const lines = selectionHistory.map((entry) => {
+    const date = new Date(entry.timestamp);
+    return `${date.toLocaleTimeString()} – ${entry.name}`;
+  });
+  historyEl.innerHTML = `<strong>History</strong><br>${lines.join('<br>')}`;
+}
+
+function openEditDialog(forfeit) {
+  editForm.name.value = forfeit.name;
+  editForm.weight.value = forfeit.weight;
+  editForm.dependencies.value = forfeit.dependencies.join(', ');
+  editForm.removeOnSelect.checked = Boolean(forfeit.removeOnSelect);
+  editDialog.returnValue = '';
+  editDialog.showModal();
+
+  function handleClose(event) {
+    if (event.target.returnValue === 'confirm') {
+      updateForfeit(forfeit.id, {
+        name: editForm.name.value,
+        weight: editForm.weight.value,
+        dependencies: editForm.dependencies.value,
+        removeOnSelect: editForm.removeOnSelect.checked,
+      });
+    }
+    editDialog.removeEventListener('close', handleClose);
+  }
+
+  editDialog.addEventListener('close', handleClose);
+}
+
+function triggerCelebration(name) {
+  if (!celebrationEl) return;
+  celebrationEl.textContent = name;
+  celebrationEl.classList.remove('hidden');
+  celebrationEl.classList.remove('show');
+
+  // Force reflow so the animation restarts even if the same name repeats
+  void celebrationEl.offsetWidth;
+
+  celebrationEl.classList.add('show');
+
+  const handleAnimationEnd = () => {
+    celebrationEl.classList.add('hidden');
+    celebrationEl.classList.remove('show');
+    celebrationEl.removeEventListener('animationend', handleAnimationEnd);
+  };
+
+  celebrationEl.addEventListener('animationend', handleAnimationEnd);
+}
+
+form.addEventListener('submit', (event) => {
+  event.preventDefault();
+  const formData = new FormData(form);
+  addForfeit({
+    name: formData.get('name'),
+    weight: formData.get('weight'),
+    dependencies: formData.get('dependencies'),
+    removeOnSelect: formData.get('removeOnSelect') !== null,
+  });
+  form.reset();
+  form.elements.weight.value = 1;
+  form.elements.removeOnSelect.checked = true;
+});
+
+spinButton.addEventListener('click', spin);
+
+toggleMenuBtn.addEventListener('click', () => {
+  menu.classList.toggle('hidden');
+  updateMenuState();
+});
+
+closeMenuBtn.addEventListener('click', () => {
+  menu.classList.add('hidden');
+  updateMenuState();
+});
+
+document.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape' && !menu.classList.contains('hidden')) {
+    menu.classList.add('hidden');
+    updateMenuState();
+  }
+});
+
+exportBtn.addEventListener('click', () => {
+  const data = JSON.stringify(forfeits, null, 2);
+  const blob = new Blob([data], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = 'forfeits.json';
+  link.click();
+  URL.revokeObjectURL(url);
+});
+
+importInput.addEventListener('change', async (event) => {
+  const file = event.target.files?.[0];
+  if (!file) return;
+  try {
+    const text = await file.text();
+    const parsed = JSON.parse(text);
+    if (!Array.isArray(parsed)) {
+      throw new Error('Invalid forfeits file');
+    }
+    const imported = parsed.map(normalizeForfeit);
+    forfeits = imported;
+    sync();
+  } catch (error) {
+    alert('Failed to import forfeits: ' + error.message);
+  } finally {
+    importInput.value = '';
+  }
+});
+
+function init() {
+  drawWheel();
+  renderList();
+  renderHistory();
+  updateMenuState();
+}
+
+init();

--- a/app.js
+++ b/app.js
@@ -24,494 +24,494 @@ let spinning = false;
 let rotation = 0;
 
 function getCompletedNames() {
-	return new Set(selectionHistory.map((item) => item.name.toLowerCase()));
+  return new Set(selectionHistory.map((item) => item.name.toLowerCase()));
 }
 
 function updateMenuState() {
-	const isOpen = !menu.classList.contains('hidden');
-	document.body.classList.toggle('menu-open', isOpen);
+  const isOpen = !menu.classList.contains('hidden');
+  document.body.classList.toggle('menu-open', isOpen);
 }
 
 function clone(value) {
-	if (typeof structuredClone === 'function') {
-		return structuredClone(value);
-	}
-	return JSON.parse(JSON.stringify(value));
+  if (typeof structuredClone === 'function') {
+    return structuredClone(value);
+  }
+  return JSON.parse(JSON.stringify(value));
 }
 
 function loadFromStorage(key, fallback) {
-	try {
-		const raw = localStorage.getItem(key);
-		if (!raw) return clone(fallback);
-		const parsed = JSON.parse(raw);
-		return parsed;
-	} catch (error) {
-		console.error('Failed to parse storage', error);
-		return clone(fallback);
-	}
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return clone(fallback);
+    const parsed = JSON.parse(raw);
+    return parsed;
+  } catch (error) {
+    console.error('Failed to parse storage', error);
+    return clone(fallback);
+  }
 }
 
 function saveToStorage(key, value) {
-	try {
-		localStorage.setItem(key, JSON.stringify(value));
-	} catch (error) {
-		console.error('Failed to save to storage', error);
-	}
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch (error) {
+    console.error('Failed to save to storage', error);
+  }
 }
 
 function createId() {
-	if (window.crypto?.randomUUID) {
-		return window.crypto.randomUUID();
-	}
-	return `forfeit-${Math.random().toString(36).slice(2, 10)}${Date.now().toString(36)}`;
+  if (window.crypto?.randomUUID) {
+    return window.crypto.randomUUID();
+  }
+  return `forfeit-${Math.random().toString(36).slice(2, 10)}${Date.now().toString(36)}`;
 }
 
 function normalizeForfeit(raw) {
-	return {
-		id: raw.id ?? createId(),
-		name: raw.name?.trim() || 'Unnamed',
-		weight: Math.max(0, Number.parseFloat(raw.weight ?? 1)) || 1,
-		dependencies: Array.isArray(raw.dependencies)
-			? raw.dependencies.map((dep) => dep.trim()).filter(Boolean)
-			: String(raw.dependencies || '')
-					.split(',')
-					.map((dep) => dep.trim())
-					.filter(Boolean),
-		removeOnSelect: Boolean(raw.removeOnSelect),
-	};
+  return {
+    id: raw.id ?? createId(),
+    name: raw.name?.trim() || 'Unnamed',
+    weight: Math.max(0, Number.parseFloat(raw.weight ?? 1)) || 1,
+    dependencies: Array.isArray(raw.dependencies)
+      ? raw.dependencies.map((dep) => dep.trim()).filter(Boolean)
+      : String(raw.dependencies || '')
+          .split(',')
+          .map((dep) => dep.trim())
+          .filter(Boolean),
+    removeOnSelect: Boolean(raw.removeOnSelect),
+  };
 }
 
 function addForfeit(raw) {
-	const forfeit = normalizeForfeit(raw);
-	forfeits.push(forfeit);
-	sync();
+  const forfeit = normalizeForfeit(raw);
+  forfeits.push(forfeit);
+  sync();
 }
 
 function updateForfeit(id, raw) {
-	const index = forfeits.findIndex((f) => f.id === id);
-	if (index === -1) return;
-	forfeits[index] = { ...forfeits[index], ...normalizeForfeit({ ...forfeits[index], ...raw, id }) };
-	sync();
+  const index = forfeits.findIndex((f) => f.id === id);
+  if (index === -1) return;
+  forfeits[index] = { ...forfeits[index], ...normalizeForfeit({ ...forfeits[index], ...raw, id }) };
+  sync();
 }
 
 function deleteForfeit(id) {
-	forfeits = forfeits.filter((f) => f.id !== id);
-	sync();
+  forfeits = forfeits.filter((f) => f.id !== id);
+  sync();
 }
 
 function sync() {
-	saveToStorage(STORAGE_KEY, forfeits);
-	drawWheel();
-	renderList();
-	updateSpinAvailability();
+  saveToStorage(STORAGE_KEY, forfeits);
+  drawWheel();
+  renderList();
+  updateSpinAvailability();
 }
 
 function renderList() {
-	list.innerHTML = '';
-	if (forfeits.length === 0) {
-		const empty = document.createElement('p');
-		empty.textContent = 'No forfeits yet. Add some to get spinning!';
-		empty.className = 'empty-state';
-		list.append(empty);
-		return;
-	}
+  list.innerHTML = '';
+  if (forfeits.length === 0) {
+    const empty = document.createElement('p');
+    empty.textContent = 'No forfeits yet. Add some to get spinning!';
+    empty.className = 'empty-state';
+    list.append(empty);
+    return;
+  }
 
-	const dependenciesMet = getCompletedNames();
+  const dependenciesMet = getCompletedNames();
 
-	for (const forfeit of forfeits) {
-		const node = template.content.firstElementChild.cloneNode(true);
-		node.dataset.id = forfeit.id;
-		node.querySelector('.forfeit-name').textContent = forfeit.name;
+  for (const forfeit of forfeits) {
+    const node = template.content.firstElementChild.cloneNode(true);
+    node.dataset.id = forfeit.id;
+    node.querySelector('.forfeit-name').textContent = forfeit.name;
 
-		const details = [];
-		details.push(`Weight: ${forfeit.weight}`);
-		if (forfeit.dependencies.length > 0) {
-			const unmet = forfeit.dependencies.filter((dep) => !dependenciesMet.has(dep.toLowerCase()));
-			const dependencyText = unmet.length
-				? `Dependencies: ${forfeit.dependencies.join(', ')} (unmet: ${unmet.join(', ')})`
-				: `Dependencies: ${forfeit.dependencies.join(', ')}`;
-			details.push(dependencyText);
-		}
-		details.push(forfeit.removeOnSelect ? 'Removed after selection' : 'Stays on wheel');
-		node.querySelector('.forfeit-details').textContent = details.join(' • ');
+    const details = [];
+    details.push(`Weight: ${forfeit.weight}`);
+    if (forfeit.dependencies.length > 0) {
+      const unmet = forfeit.dependencies.filter((dep) => !dependenciesMet.has(dep.toLowerCase()));
+      const dependencyText = unmet.length
+        ? `Dependencies: ${forfeit.dependencies.join(', ')} (unmet: ${unmet.join(', ')})`
+        : `Dependencies: ${forfeit.dependencies.join(', ')}`;
+      details.push(dependencyText);
+    }
+    details.push(forfeit.removeOnSelect ? 'Removed after selection' : 'Stays on wheel');
+    node.querySelector('.forfeit-details').textContent = details.join(' • ');
 
-		const eligible = isEligible(forfeit, dependenciesMet);
-		node.classList.toggle('ineligible', !eligible);
-		node.setAttribute('aria-disabled', String(!eligible));
+    const eligible = isEligible(forfeit, dependenciesMet);
+    node.classList.toggle('ineligible', !eligible);
+    node.setAttribute('aria-disabled', String(!eligible));
 
-		node.querySelector('.delete').addEventListener('click', () => deleteForfeit(forfeit.id));
-		node.querySelector('.edit').addEventListener('click', () => openEditDialog(forfeit));
+    node.querySelector('.delete').addEventListener('click', () => deleteForfeit(forfeit.id));
+    node.querySelector('.edit').addEventListener('click', () => openEditDialog(forfeit));
 
-		list.append(node);
-	}
+    list.append(node);
+  }
 }
 
 function getSegments(list) {
-	const totalWeight = list.reduce((sum, item) => sum + item.weight, 0);
-	if (totalWeight === 0) return [];
-	let start = 0;
-	return list.map((item, index) => {
-		const proportion = item.weight / totalWeight;
-		const angle = proportion * Math.PI * 2;
-		const segment = {
-			id: item.id,
-			item,
-			startAngle: start,
-			endAngle: start + angle,
-			index,
-			proportion,
-		};
-		start += angle;
-		return segment;
-	});
+  const totalWeight = list.reduce((sum, item) => sum + item.weight, 0);
+  if (totalWeight === 0) return [];
+  let start = 0;
+  return list.map((item, index) => {
+    const proportion = item.weight / totalWeight;
+    const angle = proportion * Math.PI * 2;
+    const segment = {
+      id: item.id,
+      item,
+      startAngle: start,
+      endAngle: start + angle,
+      index,
+      proportion,
+    };
+    start += angle;
+    return segment;
+  });
 }
 
 function drawWheel() {
-	const width = canvas.width;
-	const height = canvas.height;
-	const radius = Math.min(width, height) / 2;
-	ctx.clearRect(0, 0, width, height);
+  const width = canvas.width;
+  const height = canvas.height;
+  const radius = Math.min(width, height) / 2;
+  ctx.clearRect(0, 0, width, height);
 
-	const centerX = width / 2;
-	const centerY = height / 2;
+  const centerX = width / 2;
+  const centerY = height / 2;
 
-	if (!forfeits.length) {
-		ctx.save();
-		ctx.fillStyle = '#eee';
-		ctx.beginPath();
-		ctx.arc(centerX, centerY, radius, 0, Math.PI * 2);
-		ctx.fill();
-		ctx.fillStyle = '#666';
-		ctx.font = '20px sans-serif';
-		ctx.textAlign = 'center';
-		ctx.fillText('Add forfeits to spin', centerX, centerY);
-		ctx.restore();
-		drawPointer(centerX, centerY, radius);
-		return;
-	}
+  if (!forfeits.length) {
+    ctx.save();
+    ctx.fillStyle = '#eee';
+    ctx.beginPath();
+    ctx.arc(centerX, centerY, radius, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.fillStyle = '#666';
+    ctx.font = '20px sans-serif';
+    ctx.textAlign = 'center';
+    ctx.fillText('Add forfeits to spin', centerX, centerY);
+    ctx.restore();
+    drawPointer(centerX, centerY, radius);
+    return;
+  }
 
-	const dependenciesMet = getCompletedNames();
-	const segments = getSegments(forfeits);
-	if (segments.length === 0) {
-		ctx.save();
-		ctx.fillStyle = '#f0f0f0';
-		ctx.beginPath();
-		ctx.arc(centerX, centerY, radius, 0, Math.PI * 2);
-		ctx.fill();
-		ctx.fillStyle = '#888';
-		ctx.font = '18px sans-serif';
-		ctx.textAlign = 'center';
-		ctx.fillText('Adjust weights to spin', centerX, centerY);
-		ctx.restore();
-		drawPointer(centerX, centerY, radius);
-		return;
-	}
+  const dependenciesMet = getCompletedNames();
+  const segments = getSegments(forfeits);
+  if (segments.length === 0) {
+    ctx.save();
+    ctx.fillStyle = '#f0f0f0';
+    ctx.beginPath();
+    ctx.arc(centerX, centerY, radius, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.fillStyle = '#888';
+    ctx.font = '18px sans-serif';
+    ctx.textAlign = 'center';
+    ctx.fillText('Adjust weights to spin', centerX, centerY);
+    ctx.restore();
+    drawPointer(centerX, centerY, radius);
+    return;
+  }
 
-	ctx.save();
-	ctx.translate(centerX, centerY);
-	ctx.rotate(rotation);
+  ctx.save();
+  ctx.translate(centerX, centerY);
+  ctx.rotate(rotation);
 
-	let eligibleCount = 0;
+  let eligibleCount = 0;
 
-	segments.forEach((segment, index) => {
-		const { item, startAngle, endAngle } = segment;
-		const eligible = isEligible(item, dependenciesMet);
-		if (eligible) {
-			eligibleCount += 1;
-		}
+  segments.forEach((segment, index) => {
+    const { item, startAngle, endAngle } = segment;
+    const eligible = isEligible(item, dependenciesMet);
+    if (eligible) {
+      eligibleCount += 1;
+    }
 
-		ctx.beginPath();
-		ctx.moveTo(0, 0);
-		ctx.fillStyle = eligible ? colorForIndex(index) : 'rgba(200, 200, 200, 0.5)';
-		ctx.arc(0, 0, radius, startAngle, endAngle);
-		ctx.closePath();
-		ctx.fill();
+    ctx.beginPath();
+    ctx.moveTo(0, 0);
+    ctx.fillStyle = eligible ? colorForIndex(index) : 'rgba(200, 200, 200, 0.5)';
+    ctx.arc(0, 0, radius, startAngle, endAngle);
+    ctx.closePath();
+    ctx.fill();
 
-		ctx.save();
-		ctx.fillStyle = eligible ? '#222' : '#666';
-		ctx.rotate((startAngle + endAngle) / 2);
-		ctx.textAlign = 'right';
-		ctx.font = '16px sans-serif';
-		ctx.fillText(item.name, radius - 10, 0);
-		ctx.restore();
-	});
+    ctx.save();
+    ctx.fillStyle = eligible ? '#222' : '#666';
+    ctx.rotate((startAngle + endAngle) / 2);
+    ctx.textAlign = 'right';
+    ctx.font = '16px sans-serif';
+    ctx.fillText(item.name, radius - 10, 0);
+    ctx.restore();
+  });
 
-	ctx.restore();
-	if (eligibleCount === 0) {
-		ctx.save();
-		ctx.fillStyle = 'rgba(0, 0, 0, 0.65)';
-		ctx.beginPath();
-		ctx.arc(centerX, centerY, radius * 0.6, 0, Math.PI * 2);
-		ctx.fill();
-		ctx.fillStyle = '#fff';
-		ctx.font = 'bold 20px sans-serif';
-		ctx.textAlign = 'center';
-		ctx.fillText('All forfeits locked', centerX, centerY - 10);
-		ctx.font = '16px sans-serif';
-		ctx.fillText('Complete prerequisites to spin', centerX, centerY + 16);
-		ctx.restore();
-	}
-	drawPointer(centerX, centerY, radius);
+  ctx.restore();
+  if (eligibleCount === 0) {
+    ctx.save();
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.65)';
+    ctx.beginPath();
+    ctx.arc(centerX, centerY, radius * 0.6, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.fillStyle = '#fff';
+    ctx.font = 'bold 20px sans-serif';
+    ctx.textAlign = 'center';
+    ctx.fillText('All forfeits locked', centerX, centerY - 10);
+    ctx.font = '16px sans-serif';
+    ctx.fillText('Complete prerequisites to spin', centerX, centerY + 16);
+    ctx.restore();
+  }
+  drawPointer(centerX, centerY, radius);
 }
 
 function drawPointer(centerX, centerY, radius) {
-	ctx.save();
-	ctx.translate(centerX, centerY);
-	ctx.fillStyle = '#333';
-	ctx.beginPath();
-	ctx.moveTo(0, -radius - 10);
-	ctx.lineTo(-15, -radius + 20);
-	ctx.lineTo(15, -radius + 20);
-	ctx.closePath();
-	ctx.fill();
-	ctx.restore();
+  ctx.save();
+  ctx.translate(centerX, centerY);
+  ctx.fillStyle = '#333';
+  ctx.beginPath();
+  ctx.moveTo(0, -radius - 10);
+  ctx.lineTo(-15, -radius + 20);
+  ctx.lineTo(15, -radius + 20);
+  ctx.closePath();
+  ctx.fill();
+  ctx.restore();
 }
 
 function colorForIndex(index) {
-	const hue = (index * 137.508) % 360; // golden angle
-	return `hsl(${hue}, 70%, 60%)`;
+  const hue = (index * 137.508) % 360; // golden angle
+  return `hsl(${hue}, 70%, 60%)`;
 }
 
 function isEligible(forfeit, dependenciesMet) {
-	if (forfeit.weight <= 0) return false;
-	if (!forfeit.dependencies || forfeit.dependencies.length === 0) return true;
-	return forfeit.dependencies.every((depName) => dependenciesMet.has(depName.toLowerCase()));
+  if (forfeit.weight <= 0) return false;
+  if (!forfeit.dependencies || forfeit.dependencies.length === 0) return true;
+  return forfeit.dependencies.every((depName) => dependenciesMet.has(depName.toLowerCase()));
 }
 
 function getEligibleForfeits() {
-	const dependenciesMet = getCompletedNames();
-	return forfeits.filter((f) => isEligible(f, dependenciesMet));
+  const dependenciesMet = getCompletedNames();
+  return forfeits.filter((f) => isEligible(f, dependenciesMet));
 }
 
 function updateSpinAvailability() {
-	const eligible = getEligibleForfeits();
-	const hasEligible = eligible.length > 0;
-	spinButton.disabled = !hasEligible || spinning;
-	spinButton.title = hasEligible
-		? 'Spin the wheel'
-		: 'Add eligible forfeits with weight above zero and satisfied dependencies to spin';
-	spinButton.setAttribute('aria-disabled', String(!hasEligible));
-	if (!hasEligible && !spinning && (!resultEl.textContent || resultEl.textContent.startsWith('Waiting'))) {
-		resultEl.textContent = 'Waiting for eligible forfeits...';
-	}
+  const eligible = getEligibleForfeits();
+  const hasEligible = eligible.length > 0;
+  spinButton.disabled = !hasEligible || spinning;
+  spinButton.title = hasEligible
+    ? 'Spin the wheel'
+    : 'Add eligible forfeits with weight above zero and satisfied dependencies to spin';
+  spinButton.setAttribute('aria-disabled', String(!hasEligible));
+  if (!hasEligible && !spinning && (!resultEl.textContent || resultEl.textContent.startsWith('Waiting'))) {
+    resultEl.textContent = 'Waiting for eligible forfeits...';
+  }
 }
 
 function chooseForfeit() {
-	const eligible = getEligibleForfeits();
-	if (!eligible.length) {
-		return null;
-	}
-	const totalWeight = eligible.reduce((sum, item) => sum + item.weight, 0);
-	let threshold = Math.random() * totalWeight;
-	for (const forfeit of eligible) {
-		threshold -= forfeit.weight;
-		if (threshold <= 0) {
-			return forfeit;
-		}
-	}
-	return eligible[eligible.length - 1];
+  const eligible = getEligibleForfeits();
+  if (!eligible.length) {
+    return null;
+  }
+  const totalWeight = eligible.reduce((sum, item) => sum + item.weight, 0);
+  let threshold = Math.random() * totalWeight;
+  for (const forfeit of eligible) {
+    threshold -= forfeit.weight;
+    if (threshold <= 0) {
+      return forfeit;
+    }
+  }
+  return eligible[eligible.length - 1];
 }
 
 function getSegmentForForfeit(target) {
-	const segments = getSegments(forfeits);
-	return segments.find((segment) => segment.item.id === target.id);
+  const segments = getSegments(forfeits);
+  return segments.find((segment) => segment.item.id === target.id);
 }
 
 function animateSpin(targetSegment) {
-	return new Promise((resolve) => {
-		const pointerAngle = -Math.PI / 2;
-		const segmentCenter = (targetSegment.startAngle + targetSegment.endAngle) / 2;
-		const finalRotation = pointerAngle - segmentCenter;
-		const spins = 6 + Math.random() * 4;
-		const startRotation = rotation;
-		const targetRotation = finalRotation + spins * Math.PI * 2;
-		const duration = 5200;
-		const startTime = performance.now();
+  return new Promise((resolve) => {
+    const pointerAngle = -Math.PI / 2;
+    const segmentCenter = (targetSegment.startAngle + targetSegment.endAngle) / 2;
+    const finalRotation = pointerAngle - segmentCenter;
+    const spins = 6 + Math.random() * 4;
+    const startRotation = rotation;
+    const targetRotation = finalRotation + spins * Math.PI * 2;
+    const duration = 5200;
+    const startTime = performance.now();
 
-		function frame(now) {
-			const elapsed = now - startTime;
-			const progress = Math.min(elapsed / duration, 1);
-			const eased = easeOutExpo(progress);
-			rotation = startRotation + (targetRotation - startRotation) * eased;
-			drawWheel();
-			if (progress < 1) {
-				requestAnimationFrame(frame);
-			} else {
-				rotation = rotation % (Math.PI * 2);
-				resolve();
-			}
-		}
+    function frame(now) {
+      const elapsed = now - startTime;
+      const progress = Math.min(elapsed / duration, 1);
+      const eased = easeOutExpo(progress);
+      rotation = startRotation + (targetRotation - startRotation) * eased;
+      drawWheel();
+      if (progress < 1) {
+        requestAnimationFrame(frame);
+      } else {
+        rotation = rotation % (Math.PI * 2);
+        resolve();
+      }
+    }
 
-		requestAnimationFrame(frame);
-	});
+    requestAnimationFrame(frame);
+  });
 }
 
 function easeOutExpo(t) {
-	if (t === 1) return 1;
-	return 1 - Math.pow(2, -10 * t);
+  if (t === 1) return 1;
+  return 1 - Math.pow(2, -10 * t);
 }
 
 async function spin() {
-	if (spinning || forfeits.length === 0) return;
-	const selected = chooseForfeit();
-	if (!selected) {
-		resultEl.textContent = 'No eligible forfeits available yet.';
-		updateSpinAvailability();
-		return;
-	}
+  if (spinning || forfeits.length === 0) return;
+  const selected = chooseForfeit();
+  if (!selected) {
+    resultEl.textContent = 'No eligible forfeits available yet.';
+    updateSpinAvailability();
+    return;
+  }
 
-	const segment = getSegmentForForfeit(selected);
-	if (!segment) {
-		console.warn('Segment not found for selection');
-		return;
-	}
+  const segment = getSegmentForForfeit(selected);
+  if (!segment) {
+    console.warn('Segment not found for selection');
+    return;
+  }
 
-	spinning = true;
-	updateSpinAvailability();
-	resultEl.textContent = 'Spinning...';
+  spinning = true;
+  updateSpinAvailability();
+  resultEl.textContent = 'Spinning...';
 
-	await animateSpin(segment);
+  await animateSpin(segment);
 
-	resultEl.textContent = `Result: ${selected.name}`;
-	triggerCelebration(selected.name);
-	selectionHistory.unshift({ id: selected.id, name: selected.name, timestamp: Date.now() });
-	selectionHistory = selectionHistory.slice(0, 50);
-	saveToStorage(HISTORY_KEY, selectionHistory);
-	renderHistory();
+  resultEl.textContent = `Result: ${selected.name}`;
+  triggerCelebration(selected.name);
+  selectionHistory.unshift({ id: selected.id, name: selected.name, timestamp: Date.now() });
+  selectionHistory = selectionHistory.slice(0, 50);
+  saveToStorage(HISTORY_KEY, selectionHistory);
+  renderHistory();
 
-	if (selected.removeOnSelect) {
-		deleteForfeit(selected.id);
-	}
+  if (selected.removeOnSelect) {
+    deleteForfeit(selected.id);
+  }
 
-	spinning = false;
-	updateSpinAvailability();
+  spinning = false;
+  updateSpinAvailability();
 }
 
 function renderHistory() {
-	if (!selectionHistory.length) {
-		historyEl.textContent = 'No spins yet.';
-		return;
-	}
+  if (!selectionHistory.length) {
+    historyEl.textContent = 'No spins yet.';
+    return;
+  }
 
-	const lines = selectionHistory.map((entry) => {
-		const date = new Date(entry.timestamp);
-		return `${date.toLocaleTimeString()} – ${entry.name}`;
-	});
-	historyEl.innerHTML = `<strong>History</strong><br>${lines.join('<br>')}`;
+  const lines = selectionHistory.map((entry) => {
+    const date = new Date(entry.timestamp);
+    return `${date.toLocaleTimeString()} – ${entry.name}`;
+  });
+  historyEl.innerHTML = `<strong>History</strong><br>${lines.join('<br>')}`;
 }
 
 function openEditDialog(forfeit) {
-	editForm.name.value = forfeit.name;
-	editForm.weight.value = forfeit.weight;
-	editForm.dependencies.value = forfeit.dependencies.join(', ');
-	editForm.removeOnSelect.checked = Boolean(forfeit.removeOnSelect);
-	editDialog.returnValue = '';
-	editDialog.showModal();
+  editForm.name.value = forfeit.name;
+  editForm.weight.value = forfeit.weight;
+  editForm.dependencies.value = forfeit.dependencies.join(', ');
+  editForm.removeOnSelect.checked = Boolean(forfeit.removeOnSelect);
+  editDialog.returnValue = '';
+  editDialog.showModal();
 
-	function handleClose(event) {
-		if (event.target.returnValue === 'confirm') {
-			updateForfeit(forfeit.id, {
-				name: editForm.name.value,
-				weight: editForm.weight.value,
-				dependencies: editForm.dependencies.value,
-				removeOnSelect: editForm.removeOnSelect.checked,
-			});
-		}
-		editDialog.removeEventListener('close', handleClose);
-	}
+  function handleClose(event) {
+    if (event.target.returnValue === 'confirm') {
+      updateForfeit(forfeit.id, {
+        name: editForm.name.value,
+        weight: editForm.weight.value,
+        dependencies: editForm.dependencies.value,
+        removeOnSelect: editForm.removeOnSelect.checked,
+      });
+    }
+    editDialog.removeEventListener('close', handleClose);
+  }
 
-	editDialog.addEventListener('close', handleClose);
+  editDialog.addEventListener('close', handleClose);
 }
 
 function triggerCelebration(name) {
-	if (!celebrationEl) return;
-	celebrationEl.textContent = name;
-	celebrationEl.classList.remove('hidden');
-	celebrationEl.classList.remove('show');
+  if (!celebrationEl) return;
+  celebrationEl.textContent = name;
+  celebrationEl.classList.remove('hidden');
+  celebrationEl.classList.remove('show');
 
-	// Force reflow so the animation restarts even if the same name repeats
-	void celebrationEl.offsetWidth;
+  // Force reflow so the animation restarts even if the same name repeats
+  void celebrationEl.offsetWidth;
 
-	celebrationEl.classList.add('show');
+  celebrationEl.classList.add('show');
 
-	const handleAnimationEnd = () => {
-		celebrationEl.classList.add('hidden');
-		celebrationEl.classList.remove('show');
-		celebrationEl.removeEventListener('animationend', handleAnimationEnd);
-	};
+  const handleAnimationEnd = () => {
+    celebrationEl.classList.add('hidden');
+    celebrationEl.classList.remove('show');
+    celebrationEl.removeEventListener('animationend', handleAnimationEnd);
+  };
 
-	celebrationEl.addEventListener('animationend', handleAnimationEnd);
+  celebrationEl.addEventListener('animationend', handleAnimationEnd);
 }
 
 form.addEventListener('submit', (event) => {
-	event.preventDefault();
-	const formData = new FormData(form);
-	addForfeit({
-		name: formData.get('name'),
-		weight: formData.get('weight'),
-		dependencies: formData.get('dependencies'),
-		removeOnSelect: formData.get('removeOnSelect') !== null,
-	});
-	form.reset();
-	form.elements.weight.value = 1;
-	form.elements.removeOnSelect.checked = true;
+  event.preventDefault();
+  const formData = new FormData(form);
+  addForfeit({
+    name: formData.get('name'),
+    weight: formData.get('weight'),
+    dependencies: formData.get('dependencies'),
+    removeOnSelect: formData.get('removeOnSelect') !== null,
+  });
+  form.reset();
+  form.elements.weight.value = 1;
+  form.elements.removeOnSelect.checked = true;
 });
 
 spinButton.addEventListener('click', spin);
 
 toggleMenuBtn.addEventListener('click', () => {
-	menu.classList.toggle('hidden');
-	updateMenuState();
+  menu.classList.toggle('hidden');
+  updateMenuState();
 });
 
 closeMenuBtn.addEventListener('click', () => {
-	menu.classList.add('hidden');
-	updateMenuState();
+  menu.classList.add('hidden');
+  updateMenuState();
 });
 
 document.addEventListener('keydown', (event) => {
-	if (event.key === 'Escape' && !menu.classList.contains('hidden')) {
-		menu.classList.add('hidden');
-		updateMenuState();
-	}
+  if (event.key === 'Escape' && !menu.classList.contains('hidden')) {
+    menu.classList.add('hidden');
+    updateMenuState();
+  }
 });
 
 exportBtn.addEventListener('click', () => {
-	const data = JSON.stringify(forfeits, null, 2);
-	const blob = new Blob([data], { type: 'application/json' });
-	const url = URL.createObjectURL(blob);
-	const link = document.createElement('a');
-	link.href = url;
-	link.download = 'forfeits.json';
-	link.click();
-	URL.revokeObjectURL(url);
+  const data = JSON.stringify(forfeits, null, 2);
+  const blob = new Blob([data], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = 'forfeits.json';
+  link.click();
+  URL.revokeObjectURL(url);
 });
 
 importInput.addEventListener('change', async (event) => {
-	const file = event.target.files?.[0];
-	if (!file) return;
-	try {
-		const text = await file.text();
-		const parsed = JSON.parse(text);
-		if (!Array.isArray(parsed)) {
-			throw new Error('Invalid forfeits file');
-		}
-		const imported = parsed.map(normalizeForfeit);
-		forfeits = imported;
-		sync();
-	} catch (error) {
-		alert('Failed to import forfeits: ' + error.message);
-	} finally {
-		importInput.value = '';
-	}
+  const file = event.target.files?.[0];
+  if (!file) return;
+  try {
+    const text = await file.text();
+    const parsed = JSON.parse(text);
+    if (!Array.isArray(parsed)) {
+      throw new Error('Invalid forfeits file');
+    }
+    const imported = parsed.map(normalizeForfeit);
+    forfeits = imported;
+    sync();
+  } catch (error) {
+    alert('Failed to import forfeits: ' + error.message);
+  } finally {
+    importInput.value = '';
+  }
 });
 
 function init() {
-	drawWheel();
-	renderList();
-	renderHistory();
-	updateMenuState();
-	updateSpinAvailability();
+  drawWheel();
+  renderList();
+  renderHistory();
+  updateMenuState();
+  updateSpinAvailability();
 }
 
 init();

--- a/index.html
+++ b/index.html
@@ -1,105 +1,105 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8" />
-	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-	<title>Wheel of Forfeits</title>
-	<link rel="stylesheet" href="styles.css" />
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Wheel of Forfeits</title>
+  <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-	<header class="app-header">
-		<h1>Wheel of Forfeits</h1>
-		<div class="header-actions">
-			<button id="toggle-menu" class="primary">Manage Forfeits</button>
-			<button id="export-forfeits" class="secondary">Export</button>
-			<label class="import-label secondary">
-				Import
-				<input id="import-forfeits" type="file" accept="application/json" />
-			</label>
-		</div>
-	</header>
+  <header class="app-header">
+    <h1>Wheel of Forfeits</h1>
+    <div class="header-actions">
+      <button id="toggle-menu" class="primary">Manage Forfeits</button>
+      <button id="export-forfeits" class="secondary">Export</button>
+      <label class="import-label secondary">
+        Import
+        <input id="import-forfeits" type="file" accept="application/json" />
+      </label>
+    </div>
+  </header>
 
-	<main class="app-main">
-		<section class="wheel-panel">
-			<canvas id="wheel" width="500" height="500" aria-label="Wheel of forfeits"></canvas>
-			<button id="spin" class="spin-button primary">Spin</button>
-			<div id="result" class="result" role="status" aria-live="polite"></div>
-			<div id="celebration" class="celebration hidden" role="status" aria-live="assertive"></div>
-			<div id="history" class="history"></div>
-		</section>
+  <main class="app-main">
+    <section class="wheel-panel">
+      <canvas id="wheel" width="500" height="500" aria-label="Wheel of forfeits"></canvas>
+      <button id="spin" class="spin-button primary">Spin</button>
+      <div id="result" class="result" role="status" aria-live="polite"></div>
+      <div id="celebration" class="celebration hidden" role="status" aria-live="assertive"></div>
+      <div id="history" class="history"></div>
+    </section>
 
-		<aside id="menu" class="menu hidden" aria-label="Forfeit manager">
-			<header>
-				<h2>Forfeit Manager</h2>
-				<button type="button" id="close-menu" class="secondary">Close</button>
-			</header>
-			<form id="forfeit-form" class="forfeit-form">
-				<div class="form-row">
-					<label for="forfeit-name">Name</label>
-					<input id="forfeit-name" name="name" required />
-				</div>
-				<div class="form-row">
-					<label for="forfeit-weight">Weight</label>
-					<input id="forfeit-weight" name="weight" type="number" min="1" value="1" required />
-				</div>
-				<div class="form-row">
-					<label for="forfeit-dependencies">Dependencies<br /><small>(comma separated)</small></label>
-					<input id="forfeit-dependencies" name="dependencies" placeholder="e.g. Push-ups, Sing" />
-				</div>
-				<div class="form-row checkbox-row">
-					<input id="forfeit-remove" name="removeOnSelect" type="checkbox" checked />
-					<label for="forfeit-remove">Remove after chosen</label>
-				</div>
-				<button type="submit" class="primary">Add Forfeit</button>
-			</form>
+    <aside id="menu" class="menu hidden" aria-label="Forfeit manager">
+      <header>
+        <h2>Forfeit Manager</h2>
+        <button type="button" id="close-menu" class="secondary">Close</button>
+      </header>
+      <form id="forfeit-form" class="forfeit-form">
+        <div class="form-row">
+          <label for="forfeit-name">Name</label>
+          <input id="forfeit-name" name="name" required />
+        </div>
+        <div class="form-row">
+          <label for="forfeit-weight">Weight</label>
+          <input id="forfeit-weight" name="weight" type="number" min="1" value="1" required />
+        </div>
+        <div class="form-row">
+          <label for="forfeit-dependencies">Dependencies<br /><small>(comma separated)</small></label>
+          <input id="forfeit-dependencies" name="dependencies" placeholder="e.g. Push-ups, Sing" />
+        </div>
+        <div class="form-row checkbox-row">
+          <input id="forfeit-remove" name="removeOnSelect" type="checkbox" checked />
+          <label for="forfeit-remove">Remove after chosen</label>
+        </div>
+        <button type="submit" class="primary">Add Forfeit</button>
+      </form>
 
-			<section class="forfeit-list-section">
-				<header>
-					<h3>Current Forfeits</h3>
-				</header>
-				<ul id="forfeit-list" class="forfeit-list"></ul>
-			</section>
-		</aside>
-	</main>
+      <section class="forfeit-list-section">
+        <header>
+          <h3>Current Forfeits</h3>
+        </header>
+        <ul id="forfeit-list" class="forfeit-list"></ul>
+      </section>
+    </aside>
+  </main>
 
-	<template id="forfeit-row-template">
-		<li class="forfeit-row">
-			<div class="forfeit-summary">
-				<h4 class="forfeit-name"></h4>
-				<p class="forfeit-details"></p>
-			</div>
-			<div class="forfeit-actions">
-				<button class="secondary edit">Edit</button>
-				<button class="danger delete">Delete</button>
-			</div>
-		</li>
-	</template>
+  <template id="forfeit-row-template">
+    <li class="forfeit-row">
+      <div class="forfeit-summary">
+        <h4 class="forfeit-name"></h4>
+        <p class="forfeit-details"></p>
+      </div>
+      <div class="forfeit-actions">
+        <button class="secondary edit">Edit</button>
+        <button class="danger delete">Delete</button>
+      </div>
+    </li>
+  </template>
 
-	<dialog id="edit-dialog">
-		<form method="dialog" id="edit-form">
-			<h3>Edit Forfeit</h3>
-			<label>
-				Name
-				<input name="name" required />
-			</label>
-			<label>
-				Weight
-				<input name="weight" type="number" min="1" required />
-			</label>
-			<label>
-				Dependencies<br /><small>(comma separated)</small>
-				<input name="dependencies" />
-			</label>
-			<label class="dialog-checkbox">
-				<input name="removeOnSelect" type="checkbox" /> Remove after chosen
-			</label>
-			<menu>
-				<button value="cancel" class="secondary">Cancel</button>
-				<button value="confirm" class="primary">Save</button>
-			</menu>
-		</form>
-	</dialog>
+  <dialog id="edit-dialog">
+    <form method="dialog" id="edit-form">
+      <h3>Edit Forfeit</h3>
+      <label>
+        Name
+        <input name="name" required />
+      </label>
+      <label>
+        Weight
+        <input name="weight" type="number" min="1" required />
+      </label>
+      <label>
+        Dependencies<br /><small>(comma separated)</small>
+        <input name="dependencies" />
+      </label>
+      <label class="dialog-checkbox">
+        <input name="removeOnSelect" type="checkbox" /> Remove after chosen
+      </label>
+      <menu>
+        <button value="cancel" class="secondary">Cancel</button>
+        <button value="confirm" class="primary">Save</button>
+      </menu>
+    </form>
+  </dialog>
 
-	<script src="app.js" type="module"></script>
+  <script src="app.js" type="module"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,105 +1,105 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Wheel of Forfeits</title>
-  <link rel="stylesheet" href="styles.css" />
+	<meta charset="UTF-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	<title>Wheel of Forfeits</title>
+	<link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <header class="app-header">
-    <h1>Wheel of Forfeits</h1>
-    <div class="header-actions">
-      <button id="toggle-menu" class="primary">Manage Forfeits</button>
-      <button id="export-forfeits" class="secondary">Export</button>
-      <label class="import-label secondary">
-        Import
-        <input id="import-forfeits" type="file" accept="application/json" />
-      </label>
-    </div>
-  </header>
+	<header class="app-header">
+		<h1>Wheel of Forfeits</h1>
+		<div class="header-actions">
+			<button id="toggle-menu" class="primary">Manage Forfeits</button>
+			<button id="export-forfeits" class="secondary">Export</button>
+			<label class="import-label secondary">
+				Import
+				<input id="import-forfeits" type="file" accept="application/json" />
+			</label>
+		</div>
+	</header>
 
-  <main class="app-main">
-    <section class="wheel-panel">
-      <canvas id="wheel" width="500" height="500" aria-label="Wheel of forfeits"></canvas>
-      <button id="spin" class="spin-button primary">Spin</button>
-      <div id="result" class="result" role="status" aria-live="polite"></div>
-      <div id="celebration" class="celebration hidden" role="status" aria-live="assertive"></div>
-      <div id="history" class="history"></div>
-    </section>
+	<main class="app-main">
+		<section class="wheel-panel">
+			<canvas id="wheel" width="500" height="500" aria-label="Wheel of forfeits"></canvas>
+			<button id="spin" class="spin-button primary">Spin</button>
+			<div id="result" class="result" role="status" aria-live="polite"></div>
+			<div id="celebration" class="celebration hidden" role="status" aria-live="assertive"></div>
+			<div id="history" class="history"></div>
+		</section>
 
-    <aside id="menu" class="menu hidden" aria-label="Forfeit manager">
-      <header>
-        <h2>Forfeit Manager</h2>
-        <button type="button" id="close-menu" class="secondary">Close</button>
-      </header>
-      <form id="forfeit-form" class="forfeit-form">
-        <div class="form-row">
-          <label for="forfeit-name">Name</label>
-          <input id="forfeit-name" name="name" required />
-        </div>
-        <div class="form-row">
-          <label for="forfeit-weight">Weight</label>
-          <input id="forfeit-weight" name="weight" type="number" min="1" value="1" required />
-        </div>
-        <div class="form-row">
-          <label for="forfeit-dependencies">Dependencies<br /><small>(comma separated)</small></label>
-          <input id="forfeit-dependencies" name="dependencies" placeholder="e.g. Push-ups, Sing" />
-        </div>
-        <div class="form-row checkbox-row">
-          <input id="forfeit-remove" name="removeOnSelect" type="checkbox" checked />
-          <label for="forfeit-remove">Remove after chosen</label>
-        </div>
-        <button type="submit" class="primary">Add Forfeit</button>
-      </form>
+		<aside id="menu" class="menu hidden" aria-label="Forfeit manager">
+			<header>
+				<h2>Forfeit Manager</h2>
+				<button type="button" id="close-menu" class="secondary">Close</button>
+			</header>
+			<form id="forfeit-form" class="forfeit-form">
+				<div class="form-row">
+					<label for="forfeit-name">Name</label>
+					<input id="forfeit-name" name="name" required />
+				</div>
+				<div class="form-row">
+					<label for="forfeit-weight">Weight</label>
+					<input id="forfeit-weight" name="weight" type="number" min="1" value="1" required />
+				</div>
+				<div class="form-row">
+					<label for="forfeit-dependencies">Dependencies<br /><small>(comma separated)</small></label>
+					<input id="forfeit-dependencies" name="dependencies" placeholder="e.g. Push-ups, Sing" />
+				</div>
+				<div class="form-row checkbox-row">
+					<input id="forfeit-remove" name="removeOnSelect" type="checkbox" checked />
+					<label for="forfeit-remove">Remove after chosen</label>
+				</div>
+				<button type="submit" class="primary">Add Forfeit</button>
+			</form>
 
-      <section class="forfeit-list-section">
-        <header>
-          <h3>Current Forfeits</h3>
-        </header>
-        <ul id="forfeit-list" class="forfeit-list"></ul>
-      </section>
-    </aside>
-  </main>
+			<section class="forfeit-list-section">
+				<header>
+					<h3>Current Forfeits</h3>
+				</header>
+				<ul id="forfeit-list" class="forfeit-list"></ul>
+			</section>
+		</aside>
+	</main>
 
-  <template id="forfeit-row-template">
-    <li class="forfeit-row">
-      <div class="forfeit-summary">
-        <h4 class="forfeit-name"></h4>
-        <p class="forfeit-details"></p>
-      </div>
-      <div class="forfeit-actions">
-        <button class="secondary edit">Edit</button>
-        <button class="danger delete">Delete</button>
-      </div>
-    </li>
-  </template>
+	<template id="forfeit-row-template">
+		<li class="forfeit-row">
+			<div class="forfeit-summary">
+				<h4 class="forfeit-name"></h4>
+				<p class="forfeit-details"></p>
+			</div>
+			<div class="forfeit-actions">
+				<button class="secondary edit">Edit</button>
+				<button class="danger delete">Delete</button>
+			</div>
+		</li>
+	</template>
 
-  <dialog id="edit-dialog">
-    <form method="dialog" id="edit-form">
-      <h3>Edit Forfeit</h3>
-      <label>
-        Name
-        <input name="name" required />
-      </label>
-      <label>
-        Weight
-        <input name="weight" type="number" min="1" required />
-      </label>
-      <label>
-        Dependencies<br /><small>(comma separated)</small>
-        <input name="dependencies" />
-      </label>
-      <label class="dialog-checkbox">
-        <input name="removeOnSelect" type="checkbox" /> Remove after chosen
-      </label>
-      <menu>
-        <button value="cancel" class="secondary">Cancel</button>
-        <button value="confirm" class="primary">Save</button>
-      </menu>
-    </form>
-  </dialog>
+	<dialog id="edit-dialog">
+		<form method="dialog" id="edit-form">
+			<h3>Edit Forfeit</h3>
+			<label>
+				Name
+				<input name="name" required />
+			</label>
+			<label>
+				Weight
+				<input name="weight" type="number" min="1" required />
+			</label>
+			<label>
+				Dependencies<br /><small>(comma separated)</small>
+				<input name="dependencies" />
+			</label>
+			<label class="dialog-checkbox">
+				<input name="removeOnSelect" type="checkbox" /> Remove after chosen
+			</label>
+			<menu>
+				<button value="cancel" class="secondary">Cancel</button>
+				<button value="confirm" class="primary">Save</button>
+			</menu>
+		</form>
+	</dialog>
 
-  <script src="app.js" type="module"></script>
+	<script src="app.js" type="module"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Wheel of Forfeits</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="app-header">
+    <h1>Wheel of Forfeits</h1>
+    <div class="header-actions">
+      <button id="toggle-menu" class="primary">Manage Forfeits</button>
+      <button id="export-forfeits" class="secondary">Export</button>
+      <label class="import-label secondary">
+        Import
+        <input id="import-forfeits" type="file" accept="application/json" />
+      </label>
+    </div>
+  </header>
+
+  <main class="app-main">
+    <section class="wheel-panel">
+      <canvas id="wheel" width="500" height="500" aria-label="Wheel of forfeits"></canvas>
+      <button id="spin" class="spin-button primary">Spin</button>
+      <div id="result" class="result" role="status" aria-live="polite"></div>
+      <div id="celebration" class="celebration hidden" role="status" aria-live="assertive"></div>
+      <div id="history" class="history"></div>
+    </section>
+
+    <aside id="menu" class="menu hidden" aria-label="Forfeit manager">
+      <header>
+        <h2>Forfeit Manager</h2>
+        <button type="button" id="close-menu" class="secondary">Close</button>
+      </header>
+      <form id="forfeit-form" class="forfeit-form">
+        <div class="form-row">
+          <label for="forfeit-name">Name</label>
+          <input id="forfeit-name" name="name" required />
+        </div>
+        <div class="form-row">
+          <label for="forfeit-weight">Weight</label>
+          <input id="forfeit-weight" name="weight" type="number" min="1" value="1" required />
+        </div>
+        <div class="form-row">
+          <label for="forfeit-dependencies">Dependencies<br /><small>(comma separated)</small></label>
+          <input id="forfeit-dependencies" name="dependencies" placeholder="e.g. Push-ups, Sing" />
+        </div>
+        <div class="form-row checkbox-row">
+          <input id="forfeit-remove" name="removeOnSelect" type="checkbox" checked />
+          <label for="forfeit-remove">Remove after chosen</label>
+        </div>
+        <button type="submit" class="primary">Add Forfeit</button>
+      </form>
+
+      <section class="forfeit-list-section">
+        <header>
+          <h3>Current Forfeits</h3>
+        </header>
+        <ul id="forfeit-list" class="forfeit-list"></ul>
+      </section>
+    </aside>
+  </main>
+
+  <template id="forfeit-row-template">
+    <li class="forfeit-row">
+      <div class="forfeit-summary">
+        <h4 class="forfeit-name"></h4>
+        <p class="forfeit-details"></p>
+      </div>
+      <div class="forfeit-actions">
+        <button class="secondary edit">Edit</button>
+        <button class="danger delete">Delete</button>
+      </div>
+    </li>
+  </template>
+
+  <dialog id="edit-dialog">
+    <form method="dialog" id="edit-form">
+      <h3>Edit Forfeit</h3>
+      <label>
+        Name
+        <input name="name" required />
+      </label>
+      <label>
+        Weight
+        <input name="weight" type="number" min="1" required />
+      </label>
+      <label>
+        Dependencies<br /><small>(comma separated)</small>
+        <input name="dependencies" />
+      </label>
+      <label class="dialog-checkbox">
+        <input name="removeOnSelect" type="checkbox" /> Remove after chosen
+      </label>
+      <menu>
+        <button value="cancel" class="secondary">Cancel</button>
+        <button value="confirm" class="primary">Save</button>
+      </menu>
+    </form>
+  </dialog>
+
+  <script src="app.js" type="module"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,397 +1,397 @@
 :root {
-  color-scheme: light dark;
-  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  --bg: #f7f7f7;
-  --bg-dark: #1f1f1f;
-  --text: #202020;
-  --text-dark: #f0f0f0;
-  --primary: #007bff;
-  --primary-dark: #4092ff;
-  --secondary: #6c757d;
-  --danger: #d9534f;
-  --surface: #ffffff;
-  --surface-dark: #2c2c2c;
-  --shadow: rgba(0, 0, 0, 0.15);
+	color-scheme: light dark;
+	font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+	--bg: #f7f7f7;
+	--bg-dark: #1f1f1f;
+	--text: #202020;
+	--text-dark: #f0f0f0;
+	--primary: #007bff;
+	--primary-dark: #4092ff;
+	--secondary: #6c757d;
+	--danger: #d9534f;
+	--surface: #ffffff;
+	--surface-dark: #2c2c2c;
+	--shadow: rgba(0, 0, 0, 0.15);
 }
 
 body {
-  margin: 0;
-  background: var(--bg);
-  color: var(--text);
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
+	margin: 0;
+	background: var(--bg);
+	color: var(--text);
+	min-height: 100vh;
+	display: flex;
+	flex-direction: column;
 }
 
 body.dark {
-  background: var(--bg-dark);
-  color: var(--text-dark);
+	background: var(--bg-dark);
+	color: var(--text-dark);
 }
 
 .app-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 1rem 2rem;
-  background: linear-gradient(135deg, #6f42c1, #ff7f50);
-  color: white;
-  box-shadow: 0 2px 8px var(--shadow);
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 1rem 2rem;
+	background: linear-gradient(135deg, #6f42c1, #ff7f50);
+	color: white;
+	box-shadow: 0 2px 8px var(--shadow);
 }
 
 .header-actions {
-  display: flex;
-  gap: 0.75rem;
-  align-items: center;
+	display: flex;
+	gap: 0.75rem;
+	align-items: center;
 }
 
 .import-label {
-  position: relative;
-  overflow: hidden;
+	position: relative;
+	overflow: hidden;
 }
 
 #import-forfeits {
-  position: absolute;
-  inset: 0;
-  opacity: 0;
-  cursor: pointer;
+	position: absolute;
+	inset: 0;
+	opacity: 0;
+	cursor: pointer;
 }
 
 .app-main {
-  position: relative;
-  display: flex;
-  flex: 1;
-  overflow: hidden;
+	position: relative;
+	display: flex;
+	flex: 1;
+	overflow: hidden;
 }
 
 .wheel-panel {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 1.5rem;
-  padding: 2rem;
-  position: relative;
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 1.5rem;
+	padding: 2rem;
+	position: relative;
 }
 
 body.menu-open .wheel-panel {
-  margin-right: min(360px, 90vw);
+	margin-right: min(360px, 90vw);
 }
 
 #wheel {
-  max-width: 90vw;
-  border-radius: 50%;
-  box-shadow: 0 8px 24px var(--shadow);
-  background: radial-gradient(circle, rgba(255, 255, 255, 0.9), rgba(240, 240, 240, 0.5));
+	max-width: 90vw;
+	border-radius: 50%;
+	box-shadow: 0 8px 24px var(--shadow);
+	background: radial-gradient(circle, rgba(255, 255, 255, 0.9), rgba(240, 240, 240, 0.5));
 }
 
 .spin-button {
-  font-size: 1.25rem;
-  padding: 0.75rem 2.5rem;
+	font-size: 1.25rem;
+	padding: 0.75rem 2.5rem;
 }
 
 .result {
-  min-height: 2rem;
-  font-size: 1.5rem;
-  font-weight: bold;
-  color: #6f42c1;
+	min-height: 2rem;
+	font-size: 1.5rem;
+	font-weight: bold;
+	color: #6f42c1;
 }
 
 .history {
-  width: min(480px, 90vw);
-  max-height: 150px;
-  overflow-y: auto;
-  padding: 1rem;
-  border-radius: 12px;
-  background: rgba(111, 66, 193, 0.1);
-  box-shadow: inset 0 0 0 1px rgba(111, 66, 193, 0.2);
+	width: min(480px, 90vw);
+	max-height: 150px;
+	overflow-y: auto;
+	padding: 1rem;
+	border-radius: 12px;
+	background: rgba(111, 66, 193, 0.1);
+	box-shadow: inset 0 0 0 1px rgba(111, 66, 193, 0.2);
 }
 
 .celebration {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  padding: 1.5rem 3rem;
-  border-radius: 18px;
-  background: rgba(255, 255, 255, 0.95);
-  color: #5c2bb8;
-  font-size: clamp(2rem, 6vw, 3.75rem);
-  font-weight: 800;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  text-align: center;
-  box-shadow: 0 22px 45px rgba(60, 18, 124, 0.35);
-  pointer-events: none;
-  opacity: 0;
-  z-index: 10;
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
+	padding: 1.5rem 3rem;
+	border-radius: 18px;
+	background: rgba(255, 255, 255, 0.95);
+	color: #5c2bb8;
+	font-size: clamp(2rem, 6vw, 3.75rem);
+	font-weight: 800;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	text-align: center;
+	box-shadow: 0 22px 45px rgba(60, 18, 124, 0.35);
+	pointer-events: none;
+	opacity: 0;
+	z-index: 10;
 }
 
 .celebration.show {
-  animation: celebrationFly 1.6s ease-out forwards;
+	animation: celebrationFly 1.6s ease-out forwards;
 }
 
 .celebration.hidden {
-  display: none;
+	display: none;
 }
 
 @keyframes celebrationFly {
-  0% {
-    transform: translate(-50%, -20%) scale(0.3);
-    opacity: 0;
-  }
-  15% {
-    opacity: 1;
-  }
-  55% {
-    transform: translate(-50%, -50%) scale(1.05);
-  }
-  80% {
-    transform: translate(-50%, -48%) scale(0.95);
-  }
-  100% {
-    transform: translate(-50%, -50%) scale(1);
-    opacity: 0;
-  }
+	0% {
+		transform: translate(-50%, -20%) scale(0.3);
+		opacity: 0;
+	}
+	15% {
+		opacity: 1;
+	}
+	55% {
+		transform: translate(-50%, -50%) scale(1.05);
+	}
+	80% {
+		transform: translate(-50%, -48%) scale(0.95);
+	}
+	100% {
+		transform: translate(-50%, -50%) scale(1);
+		opacity: 0;
+	}
 }
 
 .menu {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  width: min(360px, 100%);
-  background: linear-gradient(155deg, #261447, #1b2a6b);
-  color: #fdfbff;
-  box-shadow: -4px 0 24px rgba(27, 20, 55, 0.5);
-  padding: 2rem 1.5rem;
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-  transition: transform 0.3s ease-in-out, opacity 0.3s ease-in-out;
-  transform: translateX(100%);
-  opacity: 0;
-  pointer-events: none;
+	position: absolute;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	width: min(360px, 100%);
+	background: linear-gradient(155deg, #261447, #1b2a6b);
+	color: #fdfbff;
+	box-shadow: -4px 0 24px rgba(27, 20, 55, 0.5);
+	padding: 2rem 1.5rem;
+	display: flex;
+	flex-direction: column;
+	gap: 1.5rem;
+	transition: transform 0.3s ease-in-out, opacity 0.3s ease-in-out;
+	transform: translateX(100%);
+	opacity: 0;
+	pointer-events: none;
 }
 
 .menu > header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 1rem;
 }
 
 body.dark .menu {
-  background: var(--surface-dark);
+	background: var(--surface-dark);
 }
 
 .menu:not(.hidden) {
-  transform: translateX(0);
-  opacity: 1;
-  pointer-events: auto;
+	transform: translateX(0);
+	opacity: 1;
+	pointer-events: auto;
 }
 
 .forfeit-form {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
 }
 
 .form-row {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
+	display: flex;
+	flex-direction: column;
+	gap: 0.25rem;
 }
 
 .checkbox-row {
-  flex-direction: row;
-  align-items: center;
-  gap: 0.5rem;
+	flex-direction: row;
+	align-items: center;
+	gap: 0.5rem;
 }
 
 .forfeit-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-  overflow-y: auto;
-  max-height: 40vh;
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 0.75rem;
+	overflow-y: auto;
+	max-height: 40vh;
 }
 
 .menu h2,
 .menu h3,
 .menu label,
 .menu p {
-  color: inherit;
+	color: inherit;
 }
 
 .menu input,
 .menu textarea {
-  background: rgba(255, 255, 255, 0.12);
-  color: #fdfbff;
-  border: 1px solid rgba(255, 255, 255, 0.35);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+	background: rgba(255, 255, 255, 0.12);
+	color: #fdfbff;
+	border: 1px solid rgba(255, 255, 255, 0.35);
+	box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
 }
 
 .menu input::placeholder,
 .menu textarea::placeholder {
-  color: rgba(255, 255, 255, 0.6);
+	color: rgba(255, 255, 255, 0.6);
 }
 
 .forfeit-row {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 1rem;
-  padding: 0.75rem 1rem;
-  border-radius: 10px;
-  background: rgba(255, 255, 255, 0.08);
-  box-shadow: 0 12px 24px rgba(9, 5, 40, 0.25);
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	gap: 1rem;
+	padding: 0.75rem 1rem;
+	border-radius: 10px;
+	background: rgba(255, 255, 255, 0.08);
+	box-shadow: 0 12px 24px rgba(9, 5, 40, 0.25);
 }
 
 .forfeit-row.ineligible {
-  opacity: 0.6;
-  background: rgba(255, 255, 255, 0.04);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.15);
+	opacity: 0.6;
+	background: rgba(255, 255, 255, 0.04);
+	box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.15);
 }
 
 .forfeit-row.ineligible .forfeit-name::after {
-  content: ' (locked)';
-  font-weight: 600;
-  font-size: 0.85rem;
-  color: #ffc107;
+	content: ' (locked)';
+	font-weight: 600;
+	font-size: 0.85rem;
+	color: #ffc107;
 }
 
 .forfeit-name {
-  margin: 0;
-  font-size: 1.1rem;
+	margin: 0;
+	font-size: 1.1rem;
 }
 
 .menu .forfeit-name {
-  color: #fff;
+	color: #fff;
 }
 
 .forfeit-details {
-  margin: 0.25rem 0 0;
-  font-size: 0.875rem;
-  color: rgba(68, 68, 68, 0.9);
+	margin: 0.25rem 0 0;
+	font-size: 0.875rem;
+	color: rgba(68, 68, 68, 0.9);
 }
 
 .menu .forfeit-details {
-  color: rgba(255, 249, 255, 0.75);
+	color: rgba(255, 249, 255, 0.75);
 }
 
 body.dark .menu {
-  background: linear-gradient(160deg, rgba(25, 17, 50, 0.95), rgba(18, 30, 84, 0.95));
+	background: linear-gradient(160deg, rgba(25, 17, 50, 0.95), rgba(18, 30, 84, 0.95));
 }
 
 body.dark .forfeit-row {
-  background: rgba(255, 255, 255, 0.12);
+	background: rgba(255, 255, 255, 0.12);
 }
 
 body.dark .forfeit-details {
-  color: rgba(255, 255, 255, 0.75);
+	color: rgba(255, 255, 255, 0.75);
 }
 
 body.dark .forfeit-details {
-  color: #bbb;
+	color: #bbb;
 }
 
 .forfeit-actions {
-  display: flex;
-  gap: 0.5rem;
+	display: flex;
+	gap: 0.5rem;
 }
 
 button {
-  border: none;
-  border-radius: 999px;
-  padding: 0.5rem 1.25rem;
-  font-size: 1rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
+	border: none;
+	border-radius: 999px;
+	padding: 0.5rem 1.25rem;
+	font-size: 1rem;
+	font-weight: 600;
+	cursor: pointer;
+	transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
 
 button[aria-disabled='true'],
 button:disabled {
-  cursor: not-allowed;
-  opacity: 0.65;
-  box-shadow: none;
+	cursor: not-allowed;
+	opacity: 0.65;
+	box-shadow: none;
 }
 
 button:active {
-  transform: scale(0.98);
+	transform: scale(0.98);
 }
 
 button.primary {
-  background: var(--primary);
-  color: #fff;
-  box-shadow: 0 4px 12px rgba(0, 123, 255, 0.3);
+	background: var(--primary);
+	color: #fff;
+	box-shadow: 0 4px 12px rgba(0, 123, 255, 0.3);
 }
 
 button.primary:hover,
 button.primary:focus-visible {
-  background: var(--primary-dark);
+	background: var(--primary-dark);
 }
 
 button.secondary {
-  background: var(--secondary);
-  color: white;
+	background: var(--secondary);
+	color: white;
 }
 
 button.danger {
-  background: var(--danger);
-  color: white;
+	background: var(--danger);
+	color: white;
 }
 
 input, textarea {
-  border-radius: 8px;
-  border: 1px solid rgba(0, 0, 0, 0.1);
-  padding: 0.5rem 0.75rem;
-  font-size: 1rem;
-  font-family: inherit;
+	border-radius: 8px;
+	border: 1px solid rgba(0, 0, 0, 0.1);
+	padding: 0.5rem 0.75rem;
+	font-size: 1rem;
+	font-family: inherit;
 }
 
 .dialog-checkbox {
-  display: flex;
-  gap: 0.5rem;
-  align-items: center;
-  margin-top: 0.75rem;
+	display: flex;
+	gap: 0.5rem;
+	align-items: center;
+	margin-top: 0.75rem;
 }
 
 @media (max-width: 900px) {
-  .app-main {
-    flex-direction: column;
-  }
+	.app-main {
+		flex-direction: column;
+	}
 
-  .menu {
-    top: auto;
-    right: 0;
-    left: 0;
-    bottom: 0;
-    width: 100%;
-    transform: translateY(100%);
-  }
+	.menu {
+		top: auto;
+		right: 0;
+		left: 0;
+		bottom: 0;
+		width: 100%;
+		transform: translateY(100%);
+	}
 
-  .menu:not(.hidden) {
-    transform: translateY(0);
-  }
+	.menu:not(.hidden) {
+		transform: translateY(0);
+	}
 
-  body.menu-open .wheel-panel {
-    margin-right: 0;
-    margin-bottom: 320px;
-  }
+	body.menu-open .wheel-panel {
+		margin-right: 0;
+		margin-bottom: 320px;
+	}
 }
 
 @media (prefers-color-scheme: dark) {
-  body {
-    background: var(--bg-dark);
-    color: var(--text-dark);
-  }
+	body {
+		background: var(--bg-dark);
+		color: var(--text-dark);
+	}
 
-  .result {
-    color: #ffd166;
-  }
+	.result {
+		color: #ffd166;
+	}
 }

--- a/styles.css
+++ b/styles.css
@@ -1,397 +1,397 @@
 :root {
-	color-scheme: light dark;
-	font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-	--bg: #f7f7f7;
-	--bg-dark: #1f1f1f;
-	--text: #202020;
-	--text-dark: #f0f0f0;
-	--primary: #007bff;
-	--primary-dark: #4092ff;
-	--secondary: #6c757d;
-	--danger: #d9534f;
-	--surface: #ffffff;
-	--surface-dark: #2c2c2c;
-	--shadow: rgba(0, 0, 0, 0.15);
+  color-scheme: light dark;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  --bg: #f7f7f7;
+  --bg-dark: #1f1f1f;
+  --text: #202020;
+  --text-dark: #f0f0f0;
+  --primary: #007bff;
+  --primary-dark: #4092ff;
+  --secondary: #6c757d;
+  --danger: #d9534f;
+  --surface: #ffffff;
+  --surface-dark: #2c2c2c;
+  --shadow: rgba(0, 0, 0, 0.15);
 }
 
 body {
-	margin: 0;
-	background: var(--bg);
-	color: var(--text);
-	min-height: 100vh;
-	display: flex;
-	flex-direction: column;
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
 }
 
 body.dark {
-	background: var(--bg-dark);
-	color: var(--text-dark);
+  background: var(--bg-dark);
+  color: var(--text-dark);
 }
 
 .app-header {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	padding: 1rem 2rem;
-	background: linear-gradient(135deg, #6f42c1, #ff7f50);
-	color: white;
-	box-shadow: 0 2px 8px var(--shadow);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 2rem;
+  background: linear-gradient(135deg, #6f42c1, #ff7f50);
+  color: white;
+  box-shadow: 0 2px 8px var(--shadow);
 }
 
 .header-actions {
-	display: flex;
-	gap: 0.75rem;
-	align-items: center;
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
 }
 
 .import-label {
-	position: relative;
-	overflow: hidden;
+  position: relative;
+  overflow: hidden;
 }
 
 #import-forfeits {
-	position: absolute;
-	inset: 0;
-	opacity: 0;
-	cursor: pointer;
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
 }
 
 .app-main {
-	position: relative;
-	display: flex;
-	flex: 1;
-	overflow: hidden;
+  position: relative;
+  display: flex;
+  flex: 1;
+  overflow: hidden;
 }
 
 .wheel-panel {
-	flex: 1;
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	justify-content: center;
-	gap: 1.5rem;
-	padding: 2rem;
-	position: relative;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  padding: 2rem;
+  position: relative;
 }
 
 body.menu-open .wheel-panel {
-	margin-right: min(360px, 90vw);
+  margin-right: min(360px, 90vw);
 }
 
 #wheel {
-	max-width: 90vw;
-	border-radius: 50%;
-	box-shadow: 0 8px 24px var(--shadow);
-	background: radial-gradient(circle, rgba(255, 255, 255, 0.9), rgba(240, 240, 240, 0.5));
+  max-width: 90vw;
+  border-radius: 50%;
+  box-shadow: 0 8px 24px var(--shadow);
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.9), rgba(240, 240, 240, 0.5));
 }
 
 .spin-button {
-	font-size: 1.25rem;
-	padding: 0.75rem 2.5rem;
+  font-size: 1.25rem;
+  padding: 0.75rem 2.5rem;
 }
 
 .result {
-	min-height: 2rem;
-	font-size: 1.5rem;
-	font-weight: bold;
-	color: #6f42c1;
+  min-height: 2rem;
+  font-size: 1.5rem;
+  font-weight: bold;
+  color: #6f42c1;
 }
 
 .history {
-	width: min(480px, 90vw);
-	max-height: 150px;
-	overflow-y: auto;
-	padding: 1rem;
-	border-radius: 12px;
-	background: rgba(111, 66, 193, 0.1);
-	box-shadow: inset 0 0 0 1px rgba(111, 66, 193, 0.2);
+  width: min(480px, 90vw);
+  max-height: 150px;
+  overflow-y: auto;
+  padding: 1rem;
+  border-radius: 12px;
+  background: rgba(111, 66, 193, 0.1);
+  box-shadow: inset 0 0 0 1px rgba(111, 66, 193, 0.2);
 }
 
 .celebration {
-	position: absolute;
-	top: 50%;
-	left: 50%;
-	transform: translate(-50%, -50%);
-	padding: 1.5rem 3rem;
-	border-radius: 18px;
-	background: rgba(255, 255, 255, 0.95);
-	color: #5c2bb8;
-	font-size: clamp(2rem, 6vw, 3.75rem);
-	font-weight: 800;
-	text-transform: uppercase;
-	letter-spacing: 0.05em;
-	text-align: center;
-	box-shadow: 0 22px 45px rgba(60, 18, 124, 0.35);
-	pointer-events: none;
-	opacity: 0;
-	z-index: 10;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  padding: 1.5rem 3rem;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.95);
+  color: #5c2bb8;
+  font-size: clamp(2rem, 6vw, 3.75rem);
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  text-align: center;
+  box-shadow: 0 22px 45px rgba(60, 18, 124, 0.35);
+  pointer-events: none;
+  opacity: 0;
+  z-index: 10;
 }
 
 .celebration.show {
-	animation: celebrationFly 1.6s ease-out forwards;
+  animation: celebrationFly 1.6s ease-out forwards;
 }
 
 .celebration.hidden {
-	display: none;
+  display: none;
 }
 
 @keyframes celebrationFly {
-	0% {
-		transform: translate(-50%, -20%) scale(0.3);
-		opacity: 0;
-	}
-	15% {
-		opacity: 1;
-	}
-	55% {
-		transform: translate(-50%, -50%) scale(1.05);
-	}
-	80% {
-		transform: translate(-50%, -48%) scale(0.95);
-	}
-	100% {
-		transform: translate(-50%, -50%) scale(1);
-		opacity: 0;
-	}
+  0% {
+    transform: translate(-50%, -20%) scale(0.3);
+    opacity: 0;
+  }
+  15% {
+    opacity: 1;
+  }
+  55% {
+    transform: translate(-50%, -50%) scale(1.05);
+  }
+  80% {
+    transform: translate(-50%, -48%) scale(0.95);
+  }
+  100% {
+    transform: translate(-50%, -50%) scale(1);
+    opacity: 0;
+  }
 }
 
 .menu {
-	position: absolute;
-	top: 0;
-	right: 0;
-	bottom: 0;
-	width: min(360px, 100%);
-	background: linear-gradient(155deg, #261447, #1b2a6b);
-	color: #fdfbff;
-	box-shadow: -4px 0 24px rgba(27, 20, 55, 0.5);
-	padding: 2rem 1.5rem;
-	display: flex;
-	flex-direction: column;
-	gap: 1.5rem;
-	transition: transform 0.3s ease-in-out, opacity 0.3s ease-in-out;
-	transform: translateX(100%);
-	opacity: 0;
-	pointer-events: none;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: min(360px, 100%);
+  background: linear-gradient(155deg, #261447, #1b2a6b);
+  color: #fdfbff;
+  box-shadow: -4px 0 24px rgba(27, 20, 55, 0.5);
+  padding: 2rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  transition: transform 0.3s ease-in-out, opacity 0.3s ease-in-out;
+  transform: translateX(100%);
+  opacity: 0;
+  pointer-events: none;
 }
 
 .menu > header {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	gap: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
 }
 
 body.dark .menu {
-	background: var(--surface-dark);
+  background: var(--surface-dark);
 }
 
 .menu:not(.hidden) {
-	transform: translateX(0);
-	opacity: 1;
-	pointer-events: auto;
+  transform: translateX(0);
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .forfeit-form {
-	display: flex;
-	flex-direction: column;
-	gap: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 .form-row {
-	display: flex;
-	flex-direction: column;
-	gap: 0.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
 .checkbox-row {
-	flex-direction: row;
-	align-items: center;
-	gap: 0.5rem;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .forfeit-list {
-	list-style: none;
-	margin: 0;
-	padding: 0;
-	display: flex;
-	flex-direction: column;
-	gap: 0.75rem;
-	overflow-y: auto;
-	max-height: 40vh;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  overflow-y: auto;
+  max-height: 40vh;
 }
 
 .menu h2,
 .menu h3,
 .menu label,
 .menu p {
-	color: inherit;
+  color: inherit;
 }
 
 .menu input,
 .menu textarea {
-	background: rgba(255, 255, 255, 0.12);
-	color: #fdfbff;
-	border: 1px solid rgba(255, 255, 255, 0.35);
-	box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.12);
+  color: #fdfbff;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
 }
 
 .menu input::placeholder,
 .menu textarea::placeholder {
-	color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 0.6);
 }
 
 .forfeit-row {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	gap: 1rem;
-	padding: 0.75rem 1rem;
-	border-radius: 10px;
-	background: rgba(255, 255, 255, 0.08);
-	box-shadow: 0 12px 24px rgba(9, 5, 40, 0.25);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.08);
+  box-shadow: 0 12px 24px rgba(9, 5, 40, 0.25);
 }
 
 .forfeit-row.ineligible {
-	opacity: 0.6;
-	background: rgba(255, 255, 255, 0.04);
-	box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.15);
+  opacity: 0.6;
+  background: rgba(255, 255, 255, 0.04);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.15);
 }
 
 .forfeit-row.ineligible .forfeit-name::after {
-	content: ' (locked)';
-	font-weight: 600;
-	font-size: 0.85rem;
-	color: #ffc107;
+  content: ' (locked)';
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: #ffc107;
 }
 
 .forfeit-name {
-	margin: 0;
-	font-size: 1.1rem;
+  margin: 0;
+  font-size: 1.1rem;
 }
 
 .menu .forfeit-name {
-	color: #fff;
+  color: #fff;
 }
 
 .forfeit-details {
-	margin: 0.25rem 0 0;
-	font-size: 0.875rem;
-	color: rgba(68, 68, 68, 0.9);
+  margin: 0.25rem 0 0;
+  font-size: 0.875rem;
+  color: rgba(68, 68, 68, 0.9);
 }
 
 .menu .forfeit-details {
-	color: rgba(255, 249, 255, 0.75);
+  color: rgba(255, 249, 255, 0.75);
 }
 
 body.dark .menu {
-	background: linear-gradient(160deg, rgba(25, 17, 50, 0.95), rgba(18, 30, 84, 0.95));
+  background: linear-gradient(160deg, rgba(25, 17, 50, 0.95), rgba(18, 30, 84, 0.95));
 }
 
 body.dark .forfeit-row {
-	background: rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.12);
 }
 
 body.dark .forfeit-details {
-	color: rgba(255, 255, 255, 0.75);
+  color: rgba(255, 255, 255, 0.75);
 }
 
 body.dark .forfeit-details {
-	color: #bbb;
+  color: #bbb;
 }
 
 .forfeit-actions {
-	display: flex;
-	gap: 0.5rem;
+  display: flex;
+  gap: 0.5rem;
 }
 
 button {
-	border: none;
-	border-radius: 999px;
-	padding: 0.5rem 1.25rem;
-	font-size: 1rem;
-	font-weight: 600;
-	cursor: pointer;
-	transition: transform 0.15s ease, box-shadow 0.15s ease;
+  border: none;
+  border-radius: 999px;
+  padding: 0.5rem 1.25rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
 
 button[aria-disabled='true'],
 button:disabled {
-	cursor: not-allowed;
-	opacity: 0.65;
-	box-shadow: none;
+  cursor: not-allowed;
+  opacity: 0.65;
+  box-shadow: none;
 }
 
 button:active {
-	transform: scale(0.98);
+  transform: scale(0.98);
 }
 
 button.primary {
-	background: var(--primary);
-	color: #fff;
-	box-shadow: 0 4px 12px rgba(0, 123, 255, 0.3);
+  background: var(--primary);
+  color: #fff;
+  box-shadow: 0 4px 12px rgba(0, 123, 255, 0.3);
 }
 
 button.primary:hover,
 button.primary:focus-visible {
-	background: var(--primary-dark);
+  background: var(--primary-dark);
 }
 
 button.secondary {
-	background: var(--secondary);
-	color: white;
+  background: var(--secondary);
+  color: white;
 }
 
 button.danger {
-	background: var(--danger);
-	color: white;
+  background: var(--danger);
+  color: white;
 }
 
 input, textarea {
-	border-radius: 8px;
-	border: 1px solid rgba(0, 0, 0, 0.1);
-	padding: 0.5rem 0.75rem;
-	font-size: 1rem;
-	font-family: inherit;
+  border-radius: 8px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  padding: 0.5rem 0.75rem;
+  font-size: 1rem;
+  font-family: inherit;
 }
 
 .dialog-checkbox {
-	display: flex;
-	gap: 0.5rem;
-	align-items: center;
-	margin-top: 0.75rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.75rem;
 }
 
 @media (max-width: 900px) {
-	.app-main {
-		flex-direction: column;
-	}
+  .app-main {
+    flex-direction: column;
+  }
 
-	.menu {
-		top: auto;
-		right: 0;
-		left: 0;
-		bottom: 0;
-		width: 100%;
-		transform: translateY(100%);
-	}
+  .menu {
+    top: auto;
+    right: 0;
+    left: 0;
+    bottom: 0;
+    width: 100%;
+    transform: translateY(100%);
+  }
 
-	.menu:not(.hidden) {
-		transform: translateY(0);
-	}
+  .menu:not(.hidden) {
+    transform: translateY(0);
+  }
 
-	body.menu-open .wheel-panel {
-		margin-right: 0;
-		margin-bottom: 320px;
-	}
+  body.menu-open .wheel-panel {
+    margin-right: 0;
+    margin-bottom: 320px;
+  }
 }
 
 @media (prefers-color-scheme: dark) {
-	body {
-		background: var(--bg-dark);
-		color: var(--text-dark);
-	}
+  body {
+    background: var(--bg-dark);
+    color: var(--text-dark);
+  }
 
-	.result {
-		color: #ffd166;
-	}
+  .result {
+    color: #ffd166;
+  }
 }

--- a/styles.css
+++ b/styles.css
@@ -251,6 +251,19 @@ body.dark .menu {
   box-shadow: 0 12px 24px rgba(9, 5, 40, 0.25);
 }
 
+.forfeit-row.ineligible {
+  opacity: 0.6;
+  background: rgba(255, 255, 255, 0.04);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.15);
+}
+
+.forfeit-row.ineligible .forfeit-name::after {
+  content: ' (locked)';
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: #ffc107;
+}
+
 .forfeit-name {
   margin: 0;
   font-size: 1.1rem;
@@ -299,6 +312,13 @@ button {
   font-weight: 600;
   cursor: pointer;
   transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button[aria-disabled='true'],
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+  box-shadow: none;
 }
 
 button:active {

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,377 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  --bg: #f7f7f7;
+  --bg-dark: #1f1f1f;
+  --text: #202020;
+  --text-dark: #f0f0f0;
+  --primary: #007bff;
+  --primary-dark: #4092ff;
+  --secondary: #6c757d;
+  --danger: #d9534f;
+  --surface: #ffffff;
+  --surface-dark: #2c2c2c;
+  --shadow: rgba(0, 0, 0, 0.15);
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+body.dark {
+  background: var(--bg-dark);
+  color: var(--text-dark);
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 2rem;
+  background: linear-gradient(135deg, #6f42c1, #ff7f50);
+  color: white;
+  box-shadow: 0 2px 8px var(--shadow);
+}
+
+.header-actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.import-label {
+  position: relative;
+  overflow: hidden;
+}
+
+#import-forfeits {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.app-main {
+  position: relative;
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+}
+
+.wheel-panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  padding: 2rem;
+  position: relative;
+}
+
+body.menu-open .wheel-panel {
+  margin-right: min(360px, 90vw);
+}
+
+#wheel {
+  max-width: 90vw;
+  border-radius: 50%;
+  box-shadow: 0 8px 24px var(--shadow);
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.9), rgba(240, 240, 240, 0.5));
+}
+
+.spin-button {
+  font-size: 1.25rem;
+  padding: 0.75rem 2.5rem;
+}
+
+.result {
+  min-height: 2rem;
+  font-size: 1.5rem;
+  font-weight: bold;
+  color: #6f42c1;
+}
+
+.history {
+  width: min(480px, 90vw);
+  max-height: 150px;
+  overflow-y: auto;
+  padding: 1rem;
+  border-radius: 12px;
+  background: rgba(111, 66, 193, 0.1);
+  box-shadow: inset 0 0 0 1px rgba(111, 66, 193, 0.2);
+}
+
+.celebration {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  padding: 1.5rem 3rem;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.95);
+  color: #5c2bb8;
+  font-size: clamp(2rem, 6vw, 3.75rem);
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  text-align: center;
+  box-shadow: 0 22px 45px rgba(60, 18, 124, 0.35);
+  pointer-events: none;
+  opacity: 0;
+  z-index: 10;
+}
+
+.celebration.show {
+  animation: celebrationFly 1.6s ease-out forwards;
+}
+
+.celebration.hidden {
+  display: none;
+}
+
+@keyframes celebrationFly {
+  0% {
+    transform: translate(-50%, -20%) scale(0.3);
+    opacity: 0;
+  }
+  15% {
+    opacity: 1;
+  }
+  55% {
+    transform: translate(-50%, -50%) scale(1.05);
+  }
+  80% {
+    transform: translate(-50%, -48%) scale(0.95);
+  }
+  100% {
+    transform: translate(-50%, -50%) scale(1);
+    opacity: 0;
+  }
+}
+
+.menu {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: min(360px, 100%);
+  background: linear-gradient(155deg, #261447, #1b2a6b);
+  color: #fdfbff;
+  box-shadow: -4px 0 24px rgba(27, 20, 55, 0.5);
+  padding: 2rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  transition: transform 0.3s ease-in-out, opacity 0.3s ease-in-out;
+  transform: translateX(100%);
+  opacity: 0;
+  pointer-events: none;
+}
+
+.menu > header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+body.dark .menu {
+  background: var(--surface-dark);
+}
+
+.menu:not(.hidden) {
+  transform: translateX(0);
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.forfeit-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.checkbox-row {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.forfeit-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  overflow-y: auto;
+  max-height: 40vh;
+}
+
+.menu h2,
+.menu h3,
+.menu label,
+.menu p {
+  color: inherit;
+}
+
+.menu input,
+.menu textarea {
+  background: rgba(255, 255, 255, 0.12);
+  color: #fdfbff;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.menu input::placeholder,
+.menu textarea::placeholder {
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.forfeit-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.08);
+  box-shadow: 0 12px 24px rgba(9, 5, 40, 0.25);
+}
+
+.forfeit-name {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.menu .forfeit-name {
+  color: #fff;
+}
+
+.forfeit-details {
+  margin: 0.25rem 0 0;
+  font-size: 0.875rem;
+  color: rgba(68, 68, 68, 0.9);
+}
+
+.menu .forfeit-details {
+  color: rgba(255, 249, 255, 0.75);
+}
+
+body.dark .menu {
+  background: linear-gradient(160deg, rgba(25, 17, 50, 0.95), rgba(18, 30, 84, 0.95));
+}
+
+body.dark .forfeit-row {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+body.dark .forfeit-details {
+  color: rgba(255, 255, 255, 0.75);
+}
+
+body.dark .forfeit-details {
+  color: #bbb;
+}
+
+.forfeit-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.5rem 1.25rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button:active {
+  transform: scale(0.98);
+}
+
+button.primary {
+  background: var(--primary);
+  color: #fff;
+  box-shadow: 0 4px 12px rgba(0, 123, 255, 0.3);
+}
+
+button.primary:hover,
+button.primary:focus-visible {
+  background: var(--primary-dark);
+}
+
+button.secondary {
+  background: var(--secondary);
+  color: white;
+}
+
+button.danger {
+  background: var(--danger);
+  color: white;
+}
+
+input, textarea {
+  border-radius: 8px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  padding: 0.5rem 0.75rem;
+  font-size: 1rem;
+  font-family: inherit;
+}
+
+.dialog-checkbox {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.75rem;
+}
+
+@media (max-width: 900px) {
+  .app-main {
+    flex-direction: column;
+  }
+
+  .menu {
+    top: auto;
+    right: 0;
+    left: 0;
+    bottom: 0;
+    width: 100%;
+    transform: translateY(100%);
+  }
+
+  .menu:not(.hidden) {
+    transform: translateY(0);
+  }
+
+  body.menu-open .wheel-panel {
+    margin-right: 0;
+    margin-bottom: 320px;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: var(--bg-dark);
+    color: var(--text-dark);
+  }
+
+  .result {
+    color: #ffd166;
+  }
+}


### PR DESCRIPTION
## Summary
- refresh the forfeit manager drawer with a high-contrast gradient theme and legible text controls
- introduce a celebratory fly-in banner for selected forfeits and lengthen the spin animation with a dramatic slow-down
- expose the celebration container in the markup so the overlay can be announced accessibly

## Testing
- not run (static web app)


------
https://chatgpt.com/codex/tasks/task_e_68cbd7925c8483319344fde849fc0974